### PR TITLE
Add emoji to plan messages

### DIFF
--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -67,13 +67,13 @@ except Exception:
 
 st.markdown("### 💼 Tu plan actual:")
 if plan == "free":
-    st.info("🟢 Plan gratuito (free). Algunas funciones están limitadas.")
+    st.info("🟢 Plan gratuito (free). Algunas funciones están limitadas. 😊")
 elif plan == "pro":
-    st.success("🔵 Plan PRO activo. Puedes extraer y exportar leads.")
+    st.success("🔵 Plan PRO activo. Puedes extraer y exportar leads. 😊")
 elif plan == "ilimitado":
-    st.success("🟣 Plan Ilimitado activo. Acceso completo.")
+    st.success("🟣 Plan Ilimitado activo. Acceso completo. 😊")
 else:
-    st.warning("⚠️ Plan desconocido. Vuelve a iniciar sesión si el problema persiste.")
+    st.warning("⚠️ Plan desconocido. Vuelve a iniciar sesión si el problema persiste. 😊")
 
 
 # Verificar plan del usuario


### PR DESCRIPTION
## Summary
- show a smile emoji at the end of the active plan notification in search page

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_686bbd2f1ef08323a14f757203f649e3