### PR TITLE
Optimización de velocidad con caché y logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,59 @@
-## 📋 Resumen de migración y mejoras recientes (actualizado 07/07/2025)
+README Wrapper Leads SaaS (actualizado 07/07/2025)
+📋 Resumen de migración y mejoras recientes (actualizado 07/07/2025)
 
-### ✅ 1. Preparativos y Debugging Inicial
+✅ 1. Preparativos y Debugging Inicial
 - Corrección de errores como `asyncio.run`, `await` fuera de funciones `async`, y imports faltantes.
 - Errores solucionados: `NameError: AsyncSession`, `TypeError` en corutinas, `sqlite3.OperationalError`.
 
-### ✅ 2. Migración total de SQLite a PostgreSQL
+✅ 2. Migración total de SQLite a PostgreSQL
 - PostgreSQL alojado en Render con `DATABASE_URL`.
 - Modelos migrados: Usuario, LeadTarea, LeadHistorial, LeadNota, LeadEstado, LeadExtraido, LeadInfoExtra, UsuarioMemoria.
 - Archivos clave actualizados: `main.py`, `db.py`, `models.py`, `auth.py`.
 
-### ✅ 3. Autenticación y sesiones
+✅ 3. Autenticación y sesiones
 - Sistema de login y registro con JWT y verificación de plan.
 - Endpoint `/protegido` devuelve email y plan del usuario.
 
-### ✅ 4. Planes de pago con Stripe
+✅ 4. Planes de pago con Stripe
 - Planes configurados: free, pro, ilimitado.
 - Webhook `/webhook` preparado para activar el plan tras suscripción.
 - Frontend integrado con redirección a Stripe Checkout y portal de cliente.
 
-### ✅ 5. Integración Frontend y validación de planes
+✅ 5. Integración Frontend y validación de planes
 - Consultas al endpoint `/protegido` para obtener el plan.
 - Validación de token en `st.session_state`.
 - Headers unificados para autenticación en frontend.
 
-### ✅ 6. Exportación y guardado de leads
+✅ 6. Exportación y guardado de leads
 - CSVs por usuario/nicho + CSV global (`admin_data/todos_los_leads.csv`).
 - Leads únicos por dominio guardados en PostgreSQL.
 
-### ✅ 7. Endpoints migrados
+✅ 7. Endpoints migrados
 - Autenticación: `/register`, `/login`, `/protegido`.
 - Leads y tareas: `/nota_lead`, `/guardar_info_extra`, `/tarea_lead`, `/editar_tarea`, `/historial_tareas`.
 - Exportación y búsqueda: `/exportar_csv`, `/extraer_multiples`, `/crear_checkout`.
 
-### ✅ 8. Validación en pgAdmin
+✅ 8. Validación en pgAdmin
 - Conexión externa verificada.
 - Datos persistentes tras reinicios en Render.
 
-### ✅ 9. Debugging final
+✅ 9. Debugging final
 - Manejo de errores de CSV vacío, JWT y parámetros requeridos.
 - Uso de `try-except` en lectura de CSVs.
 
-### 🟡 Pendientes
+🟡 Pendientes
 - Eliminar uso total de CSVs si se migra todo a PostgreSQL.
 - Añadir logs o panel admin.
 - Activar webhook real de Stripe al tener dominio público.
 - Edición/eliminación masiva desde base de datos.
 
-# Wrapper Leads SaaS 🚀
+Wrapper Leads SaaS 🚀
 
 Wrapper Leads SaaS es una plataforma SaaS para la extracción automática de leads desde sitios web públicos, combinando scraping inteligente, procesamiento IA y una interfaz sencilla.
 
 ---
 
-## 🧠 Objetivo del Proyecto
+🧠 Objetivo del Proyecto
 - Generar leads B2B y B2C desde dominios públicos.
 - Enriquecer resultados automáticamente con OpenAI.
 - Permitir uso sin conocimientos técnicos.
@@ -61,7 +62,7 @@ Wrapper Leads SaaS es una plataforma SaaS para la extracción automática de lea
 
 ---
 
-## 🚀 Tecnologías Usadas
+🚀 Tecnologías Usadas
 - **FastAPI** para backend (API REST).
 - **Uvicorn** como servidor ASGI.
 - **ScraperAPI + BeautifulSoup4** para scraping inteligente.
@@ -72,9 +73,8 @@ Wrapper Leads SaaS es una plataforma SaaS para la extracción automática de lea
 
 ---
 
-## 📂 Estructura del Proyecto
+📂 Estructura del Proyecto
 
-```
 wrapper-leads-saas/
 ├── backend/             # API FastAPI
 ├── scraper/             # Extracción inteligente
@@ -86,33 +86,28 @@ wrapper-leads-saas/
 ├── requirements.txt
 ├── iniciar.bat
 └── README.md
-```
 
 ---
 
-## 🛠 Instalación Local (Windows)
+🛠 Instalación Local (Windows)
 
-```bash
 git clone https://github.com/Ayrtonlink/wrapper-leads-saas.git
 cd wrapper-leads-saas
 call env\Scripts\activate.bat
 pip install -r requirements.txt
 uvicorn backend.main:app --reload
 streamlit run streamlit_app/app.py
-```
 
 Crear `.env` con:
 
-```ini
 OPENAI_API_KEY=your_openai_key
 SCRAPERAPI_KEY=your_scraperapi_key
 SECRET_KEY=una_clave_segura
 ENV=local
-```
 
 ---
 
-## ✅ Funcionalidades Principales
+✅ Funcionalidades Principales
 
 - 🔐 Registro y login de usuarios (JWT).
 - 🧠 Generación de variantes de búsqueda con IA.
@@ -134,7 +129,7 @@ ENV=local
 
 ---
 
-## 🔥 Cambios Recientes (Actualización 02/06/2025)
+🔥 Cambios Recientes (Actualización 02/06/2025)
 
 - ✅ Integración del asistente virtual en Streamlit con OpenAI.
 - ✅ Vista mejorada de tareas por tipo (general, nicho, lead).
@@ -152,7 +147,7 @@ ENV=local
 
 ---
 
-## 🆕 Cambios posteriores al 02/06/2025 (actualizado 16/06/2025)
+🆕 Cambios posteriores al 02/06/2025 (actualizado 16/06/2025)
 
 - ✅ Endpoint `/tareas_pendientes` reestructurado para mayor limpieza (extraído a `db.py`).
 - ✅ Filtrado visual de tareas completadas en la sección "Pendientes".
@@ -163,7 +158,7 @@ ENV=local
 
 
 
-## 🆕 Cambios posteriores al 27/06/2025
+🆕 Cambios posteriores al 27/06/2025
 
 - ✅ La extracción ahora solo guarda `Dominio` y `Fecha` por lead, sin emails, teléfonos ni redes sociales.
 - ✅ Eliminado el enriquecimiento IA durante la extracción para mejorar velocidad y evitar errores innecesarios.
@@ -172,7 +167,7 @@ ENV=local
 - ✅ Se oculta el campo de refinamiento si la IA responde "OK." para evitar confusión en el flujo de búsqueda.
 
 
-## 🆕 Cambios posteriores al 29/06/2025
+🆕 Cambios posteriores al 29/06/2025
 
 - ✅ Eliminado el scraping web en `/extraer_multiples`. Ahora solo se procesa el dominio base sin llamadas a ScraperAPI ni a BeautifulSoup.
 - ✅ Extracción mucho más rápida, sin costes ni retardo, ideal para grandes volúmenes.
@@ -188,7 +183,7 @@ ENV=local
 - ✅ El historial registra un evento tipo `"info"` cuando se actualiza esta información.
 - ✅ En `3_Tareas.py`, al seleccionar un dominio, se muestra un formulario editable con estos campos debajo del historial y tareas.
 
-## 🆕 Cambios posteriores al 30/06/2025
+🆕 Cambios posteriores al 30/06/2025
 
 - ✅ Añadido campo `plan` al modelo de usuarios para definir suscripción activa o gratuita.
 - ✅ Todos los nuevos registros se crean con `plan = "free"` por defecto.
@@ -207,7 +202,7 @@ ENV=local
 - ✅ Endpoint `/webhook` preparado para actualizar el plan del usuario cuando finaliza la compra.
 - ⚠️ El webhook de Stripe queda pendiente de activar cuando se tenga dominio público (requisito de Stripe).
 
-## 🆕 Cambios posteriores al 01/07/2025
+🆕 Cambios posteriores al 01/07/2025
 
 - ✅ Validación visual en frontend para evitar que usuarios con plan `free` accedan a la extracción de leads.
 - ✅ Al hacer clic en “Buscar dominios”, si el usuario no tiene suscripción, aparece un aviso con botón directo a Stripe.
@@ -218,7 +213,7 @@ ENV=local
 - ✅ El nombre del dominio en “Mis Nichos” ahora es clicable y abre la web en una nueva pestaña.
 - ✅ Lo mismo se aplica al dominio seleccionado en la sección “Leads” dentro de “Tareas”.
 
-## 🆕 Cambios posteriores al 03/07/2025
+🆕 Cambios posteriores al 03/07/2025
 
 - ✅ Rediseño visual completo de la sección de tareas en `3_Tareas.py`:
   - Las tareas generales, por lead y por nicho se dividen en dos fases: búsqueda/listado y vista individual.
@@ -238,7 +233,7 @@ ENV=local
   - Eliminado `unsafe_allow_html=True` en la tabla de tareas.
   - Reemplazado `st.experimental_get_query_params()` por `st.query_params` + `clear()` según recomendación oficial.
 
-## ❓ Pendientes Actuales
+❓ Pendientes Actuales
 
 - ❌ Migrar CSVs antiguos a base de datos.
 - 🔄 Añadir barra de progreso real durante extracción.
@@ -250,20 +245,18 @@ ENV=local
 
 ---
 
-## 🧪 Tests
+🧪 Tests
 
-```bash
 pytest tests/
-```
 
 ---
 
-## 👤 Autor
+👤 Autor
 
 - Ayrton  
 - GitHub: [Ayrtonlink](https://github.com/Ayrtonlink)
 
-## 🆕 Cambios posteriores al 27/06/2025
+🆕 Cambios posteriores al 27/06/2025
 
 - ✅ Implementado sistema visual compacto para mover leads entre nichos desde el frontend.
 - ✅ Botón 🔀 alineado horizontalmente con el dominio y el botón 🗑️, sin expanders ni popovers anidados.
@@ -273,7 +266,7 @@ pytest tests/
 - ✅ El botón de eliminar `❌` ha sido reemplazado por 🗑️ para mayor coherencia visual.
 - ✅ Todo el manejo de leads ahora se realiza en una línea compacta por lead.
 
-## 🆕 Cambios posteriores al 21/06/2025
+🆕 Cambios posteriores al 21/06/2025
 
 - ✅ El historial de tareas generales y de nichos ahora funciona correctamente y por separado.
 - ✅ El endpoint `/historial_tareas` acepta ahora un parámetro opcional `nicho` para filtrar correctamente.

--- a/backend/db.py
+++ b/backend/db.py
@@ -520,13 +520,15 @@ def obtener_historial_por_nicho_postgres(email: str, nicho: str, db: Session):
     )
     return [{"tipo": e.tipo, "descripcion": e.descripcion, "timestamp": e.timestamp} for e in eventos]
 
-def eliminar_lead_de_nicho(user_email: str, dominio: str, nicho: str):
-    with sqlite3.connect(DB_PATH) as db:
-        db.execute("""
-            DELETE FROM leads_extraidos
-            WHERE user_email = ? AND url = ? AND nicho = ?
-        """, (user_email, dominio, nicho))
-        db.commit()
+from backend.models import LeadExtraido
+
+def eliminar_lead_de_nicho(user_email: str, dominio: str, nicho: str, db: Session):
+    db.query(LeadExtraido).filter_by(
+        user_email=user_email,
+        url=dominio,
+        nicho=nicho
+    ).delete()
+    db.commit()
 
 from urllib.parse import urlparse
 

--- a/log_eliminar_lead.txt
+++ b/log_eliminar_lead.txt
@@ -33,3 +33,13 @@
 [2025-07-02 21:58:59.259603] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: mkparadise.com — Solo este nicho: True — Nicho: solodom
 [2025-07-03 20:57:37.274542] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: agenciasinmobiliarias.com.es — Solo este nicho: True — Nicho: immo
 [2025-07-08 15:55:53.063194] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: odental.es — Solo este nicho: True — Nicho: madrik
+[2025-07-10 22:23:57.533543] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: veterinariomurcia.es — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:28:18.478145] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: veterinariomurcia.es — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:29:14.924909] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: sanasanacv.com — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:30:06.946241] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: sanasanacv.com — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:30:14.276946] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: sanasanacv.com — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:31:21.054895] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: paginasamarillas.es — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:37:51.255668] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: clinicaveterinariamegamascotas.es — Solo este nicho: True — Nicho: murkia
+[2025-07-10 22:38:01.253855] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: clinicaveterinariasalzillo.com — Solo este nicho: True — Nicho: murkia
+[2025-07-13 23:09:43.063197] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: laclinicademanuela.com — Solo este nicho: True — Nicho: murkia
+[2025-07-13 23:30:26.169123] Inicio eliminación — Email: ayrton.av@gmail.com — Dominio: instagram.com — Solo este nicho: True — Nicho: murkia

--- a/scraper/extractor.py
+++ b/scraper/extractor.py
@@ -5,12 +5,14 @@ import phonenumbers
 import os
 from dotenv import load_dotenv  # ✅ Carga automática de variables
 from openai import OpenAI
+import logging
 
 # Cargar variables desde .env
 load_dotenv()
 
 # Inicializar cliente OpenAI con la clave cargada
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+logger = logging.getLogger(__name__)
 
 def validar_emails_por_regla(emails, dominio_base):
     preferidos = [e for e in emails if any(p in e for p in ["info", "contact", "hola", dominio_base])]
@@ -41,7 +43,7 @@ Tengo esta lista de {tipo}s obtenidos de una página web de un negocio:
         texto = response.choices[0].message.content.strip()
         return [x.strip() for x in texto.split(",") if x.strip()]
     except Exception as e:
-        print("⚠️ Error con OpenAI:", e)
+        logger.warning(f"Error con OpenAI: {e}")
         return lista[:2]
 
 def extraer_datos_desde_url(url: str, pais: str = "ES") -> dict:

--- a/streamlit_app/cache_utils.py
+++ b/streamlit_app/cache_utils.py
@@ -3,6 +3,7 @@ import requests
 import streamlit as st
 from dotenv import load_dotenv
 from openai import OpenAI
+from urllib.parse import urlencode
 
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
@@ -19,27 +20,47 @@ def auth_headers(token: str) -> dict:
     return {"Authorization": f"Bearer {token}"}
 
 @st.cache_data(ttl=300)
-def cached_get(endpoint: str, token: str, **params):
+def cached_get(endpoint, token, query=None, nocache=False):
+    url = f"{BACKEND_URL}/{endpoint}"
     headers = {"Authorization": f"Bearer {token}"}
+    if query:
+        url += "?" + urlencode(query)
     try:
-        r = requests.get(f"{BACKEND_URL}/{endpoint}", headers=headers, params=params, timeout=30)
-        r.raise_for_status()
-        return r.json()
-    except Exception:
-        return {}
+        if nocache:
+            response = requests.get(url, headers=headers)
+        else:
+            if not hasattr(st.session_state, "_cache"):
+                st.session_state._cache = {}
+            if url not in st.session_state._cache:
+                st.session_state._cache[url] = requests.get(url, headers=headers)
+            response = st.session_state._cache[url]
+        if response.status_code == 200:
+            return response.json()
+    except Exception as e:
+        print(f"[cached_get] Error: {e}")
+    return {}
 
-@st.cache_data(ttl=300)
-def cached_post(endpoint: str, token: str, payload: dict | None = None, **params):
+
+def cached_delete(endpoint, token, params=None):
+    url = f"{BACKEND_URL}/{endpoint}"
     headers = {"Authorization": f"Bearer {token}"}
     try:
-        r = requests.post(
-            f"{BACKEND_URL}/{endpoint}",
-            headers=headers,
-            json=payload,
-            params=params,
-            timeout=30,
-        )
-        r.raise_for_status()
-        return r.json()
-    except Exception:
-        return {}
+        r = requests.delete(url, headers=headers, params=params)
+        if r.status_code == 200:
+            return r.json()
+        return None
+    except Exception as e:
+        print(f"[cached_delete] Error: {e}")
+        return None
+
+def cached_post(endpoint, token, payload=None, params=None):
+    url = f"{BACKEND_URL}/{endpoint}"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        r = requests.post(url, headers=headers, json=payload, params=params)
+        if r.status_code == 200:
+            return r.json()
+        return None
+    except Exception as e:
+        print(f"[cached_post] Error: {e}")
+        return None

--- a/streamlit_app/cache_utils.py
+++ b/streamlit_app/cache_utils.py
@@ -1,0 +1,45 @@
+import os
+import requests
+import streamlit as st
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+
+@st.cache_resource
+def get_openai_client() -> OpenAI | None:
+    """Return a cached OpenAI client or None if API key is missing."""
+    key = os.getenv("OPENAI_API_KEY")
+    return OpenAI(api_key=key) if key else None
+
+@st.cache_data
+def auth_headers(token: str) -> dict:
+    """Authorization headers for a given token."""
+    return {"Authorization": f"Bearer {token}"}
+
+@st.cache_data(ttl=300)
+def cached_get(endpoint: str, token: str, **params):
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        r = requests.get(f"{BACKEND_URL}/{endpoint}", headers=headers, params=params, timeout=30)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return {}
+
+@st.cache_data(ttl=300)
+def cached_post(endpoint: str, token: str, payload: dict | None = None, **params):
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        r = requests.post(
+            f"{BACKEND_URL}/{endpoint}",
+            headers=headers,
+            json=payload,
+            params=params,
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return {}

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -6,7 +6,7 @@ import os
 from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
-from streamlit_app.cache_utils import cached_get, cached_post, get_openai_client, auth_headers
+from cache_utils import cached_get, cached_post, get_openai_client, auth_headers
 
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
@@ -61,7 +61,7 @@ for flag, valor in {
     "guardando_mostrado": False,
     "mostrar_resultado": False,
 }.items():
-st.session_state.setdefault(flag, valor)
+    st.session_state.setdefault(flag, valor)
 
 headers = auth_headers(st.session_state.token)
 

--- a/streamlit_app/pages/3_Tareas.py
+++ b/streamlit_app/pages/3_Tareas.py
@@ -4,12 +4,11 @@ from urllib.parse import urlparse
 from datetime import date
 import streamlit as st
 from dotenv import load_dotenv
-from streamlit_app.cache_utils import cached_get, cached_post
+from cache_utils import cached_get, cached_post
 
 # ────────────────── Config ──────────────────────────
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
-from streamlit_app.cache_utils import cached_get, cached_post
 
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
 

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -7,7 +7,7 @@ import pandas as pd
 import io
 from dotenv import load_dotenv
 from json import JSONDecodeError
-from streamlit_app.cache_utils import cached_get, cached_post
+from cache_utils import cached_get, cached_post
 
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")

--- a/streamlit_app/pages/5_Asistente_Virtual.py
+++ b/streamlit_app/pages/5_Asistente_Virtual.py
@@ -1,14 +1,15 @@
 import streamlit as st
 import os
 from dotenv import load_dotenv
-from streamlit_app.cache_utils import cached_get, get_openai_client
+from cache_utils import cached_get, get_openai_client
+
+st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")  # ✅ PRIMERO
 
 # ────────────────── Config ──────────────────────────
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
 client = get_openai_client()
 
-st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")
 st.title("🤖 Tu Asistente Virtual")
 
 if "token" not in st.session_state:


### PR DESCRIPTION
## Resumen
- agregar `get_openai_client` y `auth_headers` en utilidades de caché
- usar el cliente de OpenAI cacheado en las páginas de Streamlit
- medir tiempos en `extraer_multiples`, `exportar_csv` y `exportar_todos_mis_leads`

## Testing
- `pytest -q` *(falla por dependencias faltantes)*

------
https://chatgpt.com/codex/tasks/task_e_686e7831c0c48323b1c89a5623cdb9ad