### PR TITLE
Handle multiple Stripe events

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Este documento refleja el estado actual del proyecto tras todas las mejoras e in
 - ✅ **Integración con Stripe (portal de pago):**
   - Se añadió un botón en la página **Mi Cuenta** llamado **"Iniciar suscripción"** que abre directamente el portal de pago de Stripe para gestionar la suscripción del usuario.
   - Se creó el endpoint `/crear_portal_pago` en el backend con FastAPI que genera una sesión de Stripe (ya sea Checkout o Billing Portal).
-  - En el frontend se redirige automáticamente al enlace de Stripe o se muestra un botón clickable para usuarios en Streamlit Cloud.
+  - En el frontend se redirige automáticamente al portal de pago de Stripe al crear la sesión.
 
 - ✅ **Control de acceso según plan de suscripción:**
   - Se añadió lógica unificada para controlar las funcionalidades permitidas según el plan del usuario (`free`, `pro`, etc.).

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,10 +78,12 @@ from backend.db import (
 from backend.db import guardar_estado_lead, obtener_estado_lead
 from sqlalchemy.orm import Session
 from backend.db import obtener_nichos_para_url
+from backend.webhook import router as webhook_router
 
 load_dotenv()
 
 app = FastAPI()
+app.include_router(webhook_router)
 
 @app.on_event("startup")
 async def startup():

--- a/backend/webhook.py
+++ b/backend/webhook.py
@@ -1,0 +1,55 @@
+from fastapi import APIRouter, Request, Depends
+from sqlalchemy.orm import Session
+
+from backend.database import get_db
+from backend.auth import obtener_usuario_por_email
+
+router = APIRouter()
+
+
+def actualizar_plan_usuario(db: Session, email: str, nuevo_plan: str = "pro"):
+    """Actualiza el plan del usuario identificado por email."""
+    usuario = obtener_usuario_por_email(email, db)
+    if usuario:
+        usuario.plan = nuevo_plan
+        db.add(usuario)
+        db.commit()
+        db.refresh(usuario)
+    return usuario
+
+
+@router.post("/webhook/stripe")
+async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
+    """Recibe webhooks de Stripe y maneja distintos eventos."""
+    payload = await request.json()
+    print("Webhook recibido:", payload)
+
+    event_type = payload.get("type")
+    data_object = payload.get("data", {}).get("object", {})
+    email = data_object.get("customer_email")
+
+    if not email:
+        print("Email no encontrado en payload")
+        return {"status": "ok"}
+
+    if event_type == "checkout.session.completed":
+        actualizar_plan_usuario(db, email, "pro")
+    elif event_type == "customer.subscription.updated":
+        nickname = (
+            data_object.get("items", {})
+            .get("data", [{}])[0]
+            .get("price", {})
+            .get("nickname")
+        )
+        if nickname == "premium":
+            actualizar_plan_usuario(db, email, "premium")
+    elif event_type == "customer.subscription.deleted":
+        actualizar_plan_usuario(db, email, "free")
+    elif event_type == "invoice.payment_failed":
+        actualizar_plan_usuario(db, email, "suspendido")
+    elif event_type == "invoice.paid":
+        print(f"Pago recibido para {email}")
+    else:
+        print(f"Evento no procesado: {event_type}")
+
+    return {"status": "ok"}

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -1,6 +1,7 @@
 # 4_Mi_Cuenta.py – Página de cuenta de usuario
 
 import streamlit as st
+import streamlit.components.v1 as components
 import os
 import requests
 import pandas as pd
@@ -19,13 +20,14 @@ global_reset_button()
 if st.session_state.get("session_url"):
     session_url = st.session_state.pop("session_url")
     st.info("Redirigiendo al portal de pago...")
-    st.markdown(
+    components.html(
         f"""
         <script>
-        window.location.href = '{session_url}';
+            window.location.href = '{session_url}';
         </script>
         """,
-        unsafe_allow_html=True,
+        height=0,
+        width=0,
     )
 
 # -------------------- Autenticación --------------------

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -7,7 +7,6 @@ import pandas as pd
 import io
 from dotenv import load_dotenv
 from json import JSONDecodeError
-import streamlit.components.v1 as components
 from cache_utils import cached_get, cached_post, limpiar_cache
 from sidebar_utils import global_reset_button
 
@@ -15,6 +14,19 @@ load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mi Cuenta", page_icon="⚙️")
 global_reset_button()
+
+# Redirección automática al portal de Stripe si hay una URL almacenada
+if st.session_state.get("session_url"):
+    session_url = st.session_state.pop("session_url")
+    st.info("Redirigiendo al portal de pago...")
+    st.markdown(
+        f"""
+        <script>
+        window.location.href = '{session_url}';
+        </script>
+        """,
+        unsafe_allow_html=True,
+    )
 
 # -------------------- Autenticación --------------------
 if "token" not in st.session_state:
@@ -156,11 +168,8 @@ with col1:
                 else:
                     url = data.get("url")
                     if url:
-                        st.info("Redirigiendo al portal de pago...")
-                        components.html(
-                            f"<script>window.location.href = '{url}';</script>",
-                            height=0,
-                        )
+                        st.session_state["session_url"] = url
+                        st.rerun()
                     else:
                         st.error("La respuesta no contiene URL de Stripe.")
             else:

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -5,7 +5,6 @@ import os
 import requests
 import pandas as pd
 import io
-import webbrowser
 from dotenv import load_dotenv
 from json import JSONDecodeError
 from cache_utils import cached_get, cached_post, limpiar_cache
@@ -154,14 +153,12 @@ with col1:
                 except JSONDecodeError:
                     st.error("Respuesta inválida del servidor.")
                 else:
-                    if "url" in data:
-                        url = data["url"]
+                    url = data.get("url")
+                    if url:
                         st.markdown(
-                            f"[👉 Abrir portal de pago]({url})",
+                            f"<meta http-equiv='refresh' content='0; url={url}' />",
                             unsafe_allow_html=True,
                         )
-                        if "localhost" in BACKEND_URL:
-                            webbrowser.open(url)
                     else:
                         st.error("La respuesta no contiene URL de Stripe.")
             else:

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -7,6 +7,7 @@ import pandas as pd
 import io
 from dotenv import load_dotenv
 from json import JSONDecodeError
+import streamlit.components.v1 as components
 from cache_utils import cached_get, cached_post, limpiar_cache
 from sidebar_utils import global_reset_button
 
@@ -155,9 +156,10 @@ with col1:
                 else:
                     url = data.get("url")
                     if url:
-                        st.markdown(
-                            f"<meta http-equiv='refresh' content='0; url={url}' />",
-                            unsafe_allow_html=True,
+                        st.info("Redirigiendo al portal de pago...")
+                        components.html(
+                            f"<script>window.location.href = '{url}';</script>",
+                            height=0,
                         )
                     else:
                         st.error("La respuesta no contiene URL de Stripe.")


### PR DESCRIPTION
## Summary
- update webhook endpoint to support multiple Stripe events

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError due to missing DATABASE_URL)*
- `PYTHONPATH=. pytest -q` *(fails: DATABASE_URL unset)*
- `DATABASE_URL=sqlite:///./test.db PYTHONPATH=. pytest -q` *(fails: unauthorized responses)*

------
https://chatgpt.com/codex/tasks/task_e_688d26bf44308323a93211c1dda4b6ad