### PR TITLE
fix: make Stripe plans configurable via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@ OPENAI_API_KEY=your_openai_api_key_here
 DATABASE_URL=postgresql://user:password@host:port/database
 
 SCRAPERAPI_KEY=your_scraperapi_key_here
+
+# Stripe configuration
+STRIPE_SECRET_KEY=your_stripe_secret_key_here
+STRIPE_SUCCESS_URL=http://localhost:8501
+STRIPE_CANCEL_URL=http://localhost:8501
+STRIPE_PRICE_BASIC=your_basic_price_id
+STRIPE_PRICE_PRO=your_pro_price_id
+STRIPE_PRICE_ILIMITADO=your_ilimitado_price_id

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -296,36 +296,38 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
 
     if plan == "free":
         try:
-            # Precio por defecto del plan Pro
-            price_id = "price_1RfOhcQYGhXE7WtIbH4hvWzp"  # 👈 usa tu price_id real
-            r_checkout = requests.post(
-                f"{BACKEND_URL}/crear_checkout",
-                headers=headers,
-                params={"plan": price_id}
-            )
-            if r_checkout.ok:
-                checkout_url = safe_json(r_checkout).get("url", "")
-                st.warning("🚫 Tu suscripción actual no permite extraer leads.")
-                st.markdown(f"""
-                <div style='text-align:center; margin-top: 1rem;'>
-                    <a href="{checkout_url}" target="_blank" style='
-                        background-color: #0d6efd;
-                        color: white;
-                        padding: 0.6rem 1.4rem;
-                        border-radius: 6px;
-                        text-decoration: none;
-                        font-weight: 600;
-                        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-                        display: inline-block;
-                        transition: background-color 0.3s ease;'>
-                        💳 Suscribirme ahora
-                    </a>
-                </div>
-                """, unsafe_allow_html=True)
+            price_id = os.getenv("STRIPE_PRICE_PRO")
+            if not price_id:
+                st.error("Precio del plan PRO no configurado.")
             else:
-                st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
-        except:
-            st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
+                r_checkout = requests.post(
+                    f"{BACKEND_URL}/crear_checkout",
+                    headers=headers,
+                    params={"plan": price_id}
+                )
+                if r_checkout.ok:
+                    checkout_url = safe_json(r_checkout).get("url", "")
+                    st.warning("🚫 Tu suscripción actual no permite extraer leads.")
+                    st.markdown(f"""
+                    <div style='text-align:center; margin-top: 1rem;'>
+                        <a href="{checkout_url}" target="_blank" style='
+                            background-color: #0d6efd;
+                            color: white;
+                            padding: 0.6rem 1.4rem;
+                            border-radius: 6px;
+                            text-decoration: none;
+                            font-weight: 600;
+                            box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+                            display: inline-block;
+                            transition: background-color 0.3s ease;'>
+                            💳 Suscribirme ahora
+                        </a>
+                    </div>
+                    """, unsafe_allow_html=True)
+                else:
+                    st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
+        except Exception as e:
+            st.error(f"Error al crear checkout: {e}")
     else:
         st.session_state.fase_extraccion = "buscando"
         st.session_state.loading = True

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -149,35 +149,38 @@ col1, col2 = st.columns(2)
 with col1:
     st.markdown("**Selecciona un plan:**")
     planes = {
-        "Básico – 19,99/mes": "price_1RfOhcQYGhXE7WtIbH4hvWzp",
-        "Pro – 49,99€/mes": "price_1RfOhRQYGhXE7WtIoSxrqsG5",
-        "Ilimitado – 60€/mes": "price_1RfOhmQYGhXE7WtI49xFz469"
+        "Básico – 19,99/mes": os.getenv("STRIPE_PRICE_BASIC"),
+        "Pro – 49,99€/mes": os.getenv("STRIPE_PRICE_PRO"),
+        "Ilimitado – 60€/mes": os.getenv("STRIPE_PRICE_ILIMITADO"),
     }
     plan_elegido = st.selectbox("Planes disponibles", list(planes.keys()))
     if st.button("💳 Iniciar suscripción"):
-        price_id = planes[plan_elegido]
-        try:
-            r = requests.post(
-                f"{BACKEND_URL}/crear_portal_pago",
-                headers=headers,
-                params={"plan": price_id},
-            )
-            if r.status_code == 200:
-                try:
-                    data = r.json()
-                except JSONDecodeError:
-                    st.error("Respuesta inválida del servidor.")
-                else:
-                    url = data.get("url")
-                    if url:
-                        st.session_state["session_url"] = url
-                        st.rerun()
+        price_id = planes.get(plan_elegido)
+        if not price_id:
+            st.error("ID de precio no configurado.")
+        else:
+            try:
+                r = requests.post(
+                    f"{BACKEND_URL}/crear_portal_pago",
+                    headers=headers,
+                    params={"plan": price_id},
+                )
+                if r.status_code == 200:
+                    try:
+                        data = r.json()
+                    except JSONDecodeError:
+                        st.error("Respuesta inválida del servidor.")
                     else:
-                        st.error("La respuesta no contiene URL de Stripe.")
-            else:
-                st.error("No se pudo iniciar el pago.")
-        except Exception as e:
-            st.error(f"Error: {e}")
+                        url = data.get("url")
+                        if url:
+                            st.session_state["session_url"] = url
+                            st.rerun()
+                        else:
+                            st.error("La respuesta no contiene URL de Stripe.")
+                else:
+                    st.error("No se pudo iniciar el pago.")
+            except Exception as e:
+                st.error(f"Error: {e}")
 
 with col2:
     if st.button("🧾 Gestionar suscripción"):


### PR DESCRIPTION
## Summary
- load Stripe price IDs from environment variables instead of hardcoded values
- document required Stripe environment variables

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_68910ce7bbdc8323b6ee2f6b3d369b77