### PR TITLE
Fix subscription price configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 DATABASE_URL=postgresql://user:password@host:port/database
 
 SCRAPERAPI_KEY=your_scraperapi_key_here
+
+# Stripe price IDs
+STRIPE_PRICE_BASIC=
+STRIPE_PRICE_PRO=
+STRIPE_PRICE_ILIMITADO=

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -296,8 +296,11 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
 
     if plan == "free":
         try:
-            # Precio por defecto del plan Pro
-            price_id = "price_1RfOhcQYGhXE7WtIbH4hvWzp"  # 👈 usa tu price_id real
+            # Precio por defecto del plan Básico
+            price_id = os.getenv("STRIPE_PRICE_BASIC", "")
+            if not price_id:
+                st.error("Falta configurar el price_id del plan Básico.")
+                st.stop()
             r_checkout = requests.post(
                 f"{BACKEND_URL}/crear_checkout",
                 headers=headers,
@@ -324,7 +327,7 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
                 """, unsafe_allow_html=True)
             else:
                 st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
-        except:
+        except Exception:
             st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
     else:
         st.session_state.fase_extraccion = "buscando"

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -149,35 +149,38 @@ col1, col2 = st.columns(2)
 with col1:
     st.markdown("**Selecciona un plan:**")
     planes = {
-        "Básico – 19,99/mes": "price_1RfOhcQYGhXE7WtIbH4hvWzp",
-        "Pro – 49,99€/mes": "price_1RfOhRQYGhXE7WtIoSxrqsG5",
-        "Ilimitado – 60€/mes": "price_1RfOhmQYGhXE7WtI49xFz469"
+        "Básico – 19,99/mes": os.getenv("STRIPE_PRICE_BASIC", ""),
+        "Pro – 49,99€/mes": os.getenv("STRIPE_PRICE_PRO", ""),
+        "Ilimitado – 60€/mes": os.getenv("STRIPE_PRICE_ILIMITADO", ""),
     }
-    plan_elegido = st.selectbox("Planes disponibles", list(planes.keys()))
-    if st.button("💳 Iniciar suscripción"):
-        price_id = planes[plan_elegido]
-        try:
-            r = requests.post(
-                f"{BACKEND_URL}/crear_portal_pago",
-                headers=headers,
-                params={"plan": price_id},
-            )
-            if r.status_code == 200:
-                try:
-                    data = r.json()
-                except JSONDecodeError:
-                    st.error("Respuesta inválida del servidor.")
-                else:
-                    url = data.get("url")
-                    if url:
-                        st.session_state["session_url"] = url
-                        st.rerun()
+    if not all(planes.values()):
+        st.error("Faltan configuraciones de precios de Stripe.")
+    else:
+        plan_elegido = st.selectbox("Planes disponibles", list(planes.keys()))
+        if st.button("💳 Iniciar suscripción"):
+            price_id = planes[plan_elegido]
+            try:
+                r = requests.post(
+                    f"{BACKEND_URL}/crear_portal_pago",
+                    headers=headers,
+                    params={"plan": price_id},
+                )
+                if r.status_code == 200:
+                    try:
+                        data = r.json()
+                    except JSONDecodeError:
+                        st.error("Respuesta inválida del servidor.")
                     else:
-                        st.error("La respuesta no contiene URL de Stripe.")
-            else:
-                st.error("No se pudo iniciar el pago.")
-        except Exception as e:
-            st.error(f"Error: {e}")
+                        url = data.get("url")
+                        if url:
+                            st.session_state["session_url"] = url
+                            st.rerun()
+                        else:
+                            st.error("La respuesta no contiene URL de Stripe.")
+                else:
+                    st.error("No se pudo iniciar el pago.")
+            except Exception as e:
+                st.error(f"Error: {e}")
 
 with col2:
     if st.button("🧾 Gestionar suscripción"):


### PR DESCRIPTION
## Summary
- load Stripe price ids from environment in Streamlit pages
- document required STRIPE_PRICE_* variables

## Testing
- `DATABASE_URL=sqlite:// PYTHONPATH=. pytest tests/test_api.py::test_extraer_datos_valido -q` *(fails: 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_68911aa2d33483238d31eb82ed6c5ba5