### PR TITLE
Fix subscription price configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,8 @@ OPENAI_API_KEY=your_openai_api_key_here
 DATABASE_URL=postgresql://user:password@host:port/database
 
 SCRAPERAPI_KEY=your_scraperapi_key_here
+
+# Stripe price IDs
+STRIPE_PRICE_BASIC=
+STRIPE_PRICE_PRO=
+STRIPE_PRICE_ILIMITADO=

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -296,8 +296,11 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
 
     if plan == "free":
         try:
-            # Precio por defecto del plan Pro
-            price_id = "price_1RfOhcQYGhXE7WtIbH4hvWzp"  # 👈 usa tu price_id real
+            # Precio por defecto del plan Básico
+            price_id = os.getenv("STRIPE_PRICE_BASIC", "")
+            if not price_id:
+                st.error("Falta configurar el price_id del plan Básico.")
+                st.stop()
             r_checkout = requests.post(
                 f"{BACKEND_URL}/crear_checkout",
                 headers=headers,
@@ -324,7 +327,7 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
                 """, unsafe_allow_html=True)
             else:
                 st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
-        except:
+        except Exception:
             st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
     else:
         st.session_state.fase_extraccion = "buscando"

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -16,19 +16,6 @@ BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mi Cuenta", page_icon="⚙️")
 global_reset_button()
 
-# Redirección automática al portal de Stripe si hay una URL almacenada
-if st.session_state.get("session_url"):
-    session_url = st.session_state.pop("session_url")
-    st.info("Redirigiendo al portal de pago...")
-    components.html(
-        f"""
-        <script>
-            window.location.href = '{session_url}';
-        </script>
-        """,
-        height=0,
-        width=0,
-    )
 
 # -------------------- Autenticación --------------------
 if "token" not in st.session_state:
@@ -75,7 +62,9 @@ st.text(f"Plan detectado: {plan}")
 st.subheader("📄 Plan actual")
 if plan == "free":
     st.success("Tu plan actual es: free")
-    st.warning("Algunas funciones están bloqueadas. Suscríbete para desbloquear la extracción y exportación de leads.")
+    st.warning(
+        "Algunas funciones están bloqueadas. Suscríbete para desbloquear la extracción y exportación de leads."
+    )
 elif plan == "pro":
     st.success("Tu plan actual es: pro")
 elif plan == "ilimitado":
@@ -85,14 +74,20 @@ else:
 
 # -------------------- Memoria del usuario --------------------
 st.subheader("🧠 Memoria personalizada")
-st.caption("Describe brevemente tu negocio, tus objetivos y el tipo de cliente que buscas.")
+st.caption(
+    "Describe brevemente tu negocio, tus objetivos y el tipo de cliente que buscas."
+)
 
 resp = cached_get("mi_memoria", st.session_state.token)
 memoria = resp.get("memoria", "") if resp else ""
 nueva_memoria = st.text_area("Tu descripción de negocio", value=memoria, height=200)
 
 if st.button("💾 Guardar memoria"):
-    r = cached_post("mi_memoria", st.session_state.token, payload={"descripcion": nueva_memoria.strip()})
+    r = cached_post(
+        "mi_memoria",
+        st.session_state.token,
+        payload={"descripcion": nueva_memoria.strip()},
+    )
     if r:
         limpiar_cache()
         st.success("Memoria guardada correctamente.")
@@ -114,11 +109,13 @@ if leads_resp.status_code == 200:
 resp_tareas = cached_get("tareas_pendientes", st.session_state.token)
 tareas = resp_tareas.get("tareas", []) if resp_tareas else []
 
-st.markdown(f"""
+st.markdown(
+    f"""
 - 🧠 **Nichos activos:** {len(nichos)}
 - 🌐 **Leads extraídos:** {total_leads}
 - 📋 **Tareas pendientes:** {len(tareas)}
-""")
+"""
+)
 
 # -------------------- Cambio de contraseña --------------------
 st.subheader("🔐 Cambiar contraseña")
@@ -139,7 +136,11 @@ with st.form("form_pass"):
             if r:
                 st.success("Contraseña actualizada correctamente.")
             else:
-                st.error(r.get("detail", "Error al cambiar contraseña.") if isinstance(r, dict) else "Error al cambiar contraseña.")
+                st.error(
+                    r.get("detail", "Error al cambiar contraseña.")
+                    if isinstance(r, dict)
+                    else "Error al cambiar contraseña."
+                )
 
 # -------------------- Suscripción --------------------
 st.subheader("💳 Suscripción")
@@ -149,35 +150,49 @@ col1, col2 = st.columns(2)
 with col1:
     st.markdown("**Selecciona un plan:**")
     planes = {
-        "Básico – 19,99/mes": "price_1RfOhcQYGhXE7WtIbH4hvWzp",
-        "Pro – 49,99€/mes": "price_1RfOhRQYGhXE7WtIoSxrqsG5",
-        "Ilimitado – 60€/mes": "price_1RfOhmQYGhXE7WtI49xFz469"
+        "Básico – 19,99/mes": os.getenv("STRIPE_PRICE_BASIC", ""),
+        "Pro – 49,99€/mes": os.getenv("STRIPE_PRICE_PRO", ""),
+        "Ilimitado – 60€/mes": os.getenv("STRIPE_PRICE_ILIMITADO", ""),
     }
-    plan_elegido = st.selectbox("Planes disponibles", list(planes.keys()))
-    if st.button("💳 Iniciar suscripción"):
-        price_id = planes[plan_elegido]
-        try:
-            r = requests.post(
-                f"{BACKEND_URL}/crear_portal_pago",
-                headers=headers,
-                params={"plan": price_id},
-            )
-            if r.status_code == 200:
-                try:
-                    data = r.json()
-                except JSONDecodeError:
-                    st.error("Respuesta inválida del servidor.")
-                else:
-                    url = data.get("url")
-                    if url:
-                        st.session_state["session_url"] = url
-                        st.rerun()
+    if not all(planes.values()):
+        st.error("Faltan configuraciones de precios de Stripe.")
+    else:
+        plan_elegido = st.selectbox("Planes disponibles", list(planes.keys()))
+        if st.button("💳 Iniciar suscripción"):
+            price_id = planes[plan_elegido]
+            try:
+                r = requests.post(
+                    f"{BACKEND_URL}/crear_portal_pago",
+                    headers=headers,
+                    params={"plan": price_id},
+                )
+                if r.status_code == 200:
+                    try:
+                        data = r.json()
+                    except JSONDecodeError:
+                        st.error("Respuesta inválida del servidor.")
                     else:
-                        st.error("La respuesta no contiene URL de Stripe.")
-            else:
-                st.error("No se pudo iniciar el pago.")
-        except Exception as e:
-            st.error(f"Error: {e}")
+                        url = data.get("url")
+                        if url:
+                            st.success("Redirigiendo a Stripe...")
+                            st.markdown(
+                                f"[Haz clic aquí si no se abre automáticamente]({url})",
+                                unsafe_allow_html=True,
+                            )
+                            components.html(
+                                f"""
+                                <script>
+                                    window.location.href = '{url}';
+                                </script>
+                                """,
+                                height=0,
+                            )
+                        else:
+                            st.error("La respuesta no contiene URL de Stripe.")
+                else:
+                    st.error("No se pudo iniciar el pago.")
+            except Exception as e:
+                st.error(f"Error: {e}")
 
 with col2:
     if st.button("🧾 Gestionar suscripción"):
@@ -186,7 +201,9 @@ with col2:
             if r and r.get("url"):
                 url_portal = r.get("url", "")
                 st.success("Abriendo portal de cliente...")
-                st.markdown(f"[👉 Abrir portal de Stripe]({url_portal})", unsafe_allow_html=True)
+                st.markdown(
+                    f"[👉 Abrir portal de Stripe]({url_portal})", unsafe_allow_html=True
+                )
             else:
                 st.error("No se pudo abrir el portal del cliente.")
         except Exception as e:


### PR DESCRIPTION
## Summary
- load Stripe price ids from environment in Streamlit pages
- document required STRIPE_PRICE_* variables
- automatically redirect to Stripe checkout with a manual fallback link

## Testing
- `DATABASE_URL=sqlite:// PYTHONPATH=. pytest tests/test_api.py::test_extraer_datos_valido -q` *(fails: 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_e_68911aa2d33483238d31eb82ed6c5ba5