### PR TITLE
Remove cookie-based Streamlit session persistence

### DIFF
--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -1,26 +1,15 @@
 import os
 import requests
 import streamlit as st
-import streamlit.components.v1 as components
 from dotenv import load_dotenv
-from streamlit_js_eval import get_cookie, set_cookie
+from cache_utils import limpiar_cache
 
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
 
 
-def set_token_cookie(token: str) -> None:
-    set_cookie("wrapper_token", token, 7)
-
-
 def ensure_token_and_user() -> None:
-    if "token" not in st.session_state and not st.session_state.get("logout_flag"):
-        token = get_cookie("wrapper_token")
-        if token:
-            st.session_state.token = token
-
     if "token" in st.session_state:
-        set_token_cookie(st.session_state.token)
         if st.session_state.get("logout_flag"):
             del st.session_state["logout_flag"]
 
@@ -38,16 +27,10 @@ def ensure_token_and_user() -> None:
             except Exception:
                 pass
 
+
 def logout_button() -> None:
     if st.sidebar.button("Cerrar sesión"):
-        components.html(
-            """
-            <script>
-            document.cookie = 'wrapper_token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-            </script>
-            """,
-            height=0,
-        )
+        limpiar_cache()
         st.session_state.clear()
         st.session_state.logout_flag = True
         st.rerun()

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from json import JSONDecodeError
 from cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
 from sidebar_utils import global_reset_button
-from auth_utils import ensure_token_and_user, set_token_cookie, logout_button
+from auth_utils import ensure_token_and_user, logout_button
 
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
@@ -46,7 +46,6 @@ def login():
             data = safe_json(r)
             st.session_state.token = data.get("access_token")
             st.session_state.email = email
-            set_token_cookie(st.session_state.token)
             st.rerun()
         else:
             st.error("Credenciales inválidas")


### PR DESCRIPTION
## Summary
- Drop JWT cookie handling to avoid automatic re-login after closing tabs
- Clear Streamlit caches during logout for a clean session reset
- Simplify login flow by removing unused cookie utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
- `PYTHONPATH=$PWD pytest -q` *(fails: Expected string or URL object, got None)*
- `DATABASE_URL=sqlite:// PYTHONPATH=$PWD pytest tests/test_api.py::test_dummy -q` *(fails: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68951c5d40288323a82f1c774b654d9f