### PR TITLE
Use JS redirect for Stripe portals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ stripe
 # Frontend
 streamlit
 streamlit_js_eval
+extra-streamlit-components
 
 # Data
 pandas

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -3,6 +3,9 @@
 import streamlit as st
 
 from auth_utils import ensure_token_and_user, logout_button
+from cookies_utils import init_cookie_manager_mount
+
+init_cookie_manager_mount()
 
 st.set_page_config(page_title="Wrapper Leads SaaS", page_icon="🕵️‍♂️")
 logout_button()

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -2,11 +2,9 @@
 
 import streamlit as st
 
-from sidebar_utils import global_reset_button
 from auth_utils import ensure_token_and_user, logout_button
 
 st.set_page_config(page_title="Wrapper Leads SaaS", page_icon="🕵️‍♂️")
-global_reset_button()
 logout_button()
 ensure_token_and_user()
 st.title("🧠 Wrapper Leads SaaS")

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,11 +1,10 @@
 """Main entry point for the Streamlit app."""
 
 import streamlit as st
+from session_bootstrap import bootstrap
 
+bootstrap()
 from auth_utils import ensure_token_and_user, logout_button
-from cookies_utils import init_cookie_manager_mount
-
-init_cookie_manager_mount()
 
 st.set_page_config(page_title="Wrapper Leads SaaS", page_icon="🕵️‍♂️")
 logout_button()

--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -2,6 +2,7 @@ import os, streamlit as st
 import requests
 from dotenv import load_dotenv
 from cache_utils import limpiar_cache
+from cookies_utils import get_cm, clear_auth_cookies
 
 load_dotenv()
 BACKEND_URL = (
@@ -12,6 +13,15 @@ BACKEND_URL = (
 
 
 def ensure_token_and_user() -> None:
+    if "token" not in st.session_state:
+        cm = get_cm()
+        token = cm.get("wrapper_token")
+        if token:
+            st.session_state.token = token
+            email = cm.get("wrapper_email")
+            if email:
+                st.session_state.email = email
+
     if "token" in st.session_state:
         if st.session_state.get("logout_flag"):
             del st.session_state["logout_flag"]
@@ -34,6 +44,7 @@ def ensure_token_and_user() -> None:
 def logout_button() -> None:
     if st.sidebar.button("Cerrar sesión"):
         limpiar_cache()
+        clear_auth_cookies()
         st.session_state.clear()
         st.session_state.logout_flag = True
         st.rerun()

--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -1,11 +1,14 @@
-import os
+import os, streamlit as st
 import requests
-import streamlit as st
 from dotenv import load_dotenv
 from cache_utils import limpiar_cache
 
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 
 
 def ensure_token_and_user() -> None:

--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -14,6 +14,7 @@ BACKEND_URL = (
     or os.getenv("BACKEND_URL")
     or "https://opensells.onrender.com"
 )
+ENV = st.secrets.get("ENV") or os.getenv("ENV")
 
 
 def ensure_token_and_user() -> None:
@@ -38,6 +39,10 @@ def ensure_token_and_user() -> None:
                     st.session_state.clear()
             except Exception:
                 pass
+
+    if ENV == "dev":
+        st.write("DEBUG token in session:", "token" in st.session_state)
+        st.write("DEBUG token from cookies:", get_auth_token())
 
 
 def logout_button() -> None:

--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -2,7 +2,11 @@ import os, streamlit as st
 import requests
 from dotenv import load_dotenv
 from cache_utils import limpiar_cache
-from cookies_utils import get_cm, clear_auth_cookies
+from cookies_utils import (
+    get_auth_token,
+    get_auth_email,
+    clear_auth_cookies,
+)
 
 load_dotenv()
 BACKEND_URL = (
@@ -14,18 +18,13 @@ BACKEND_URL = (
 
 def ensure_token_and_user() -> None:
     if "token" not in st.session_state:
-        cm = get_cm()
-        token = cm.get("wrapper_token")
+        token = get_auth_token()
         if token:
             st.session_state.token = token
-            email = cm.get("wrapper_email")
-            if email:
-                st.session_state.email = email
+            if "email" not in st.session_state:
+                st.session_state.email = get_auth_email()
 
     if "token" in st.session_state:
-        if st.session_state.get("logout_flag"):
-            del st.session_state["logout_flag"]
-
         if "usuario" not in st.session_state:
             try:
                 r = requests.get(
@@ -46,5 +45,9 @@ def logout_button() -> None:
         limpiar_cache()
         clear_auth_cookies()
         st.session_state.clear()
-        st.session_state.logout_flag = True
+        st.experimental_set_query_params()
+        try:
+            st.switch_page("pages/1_Busqueda.py")
+        except Exception:
+            pass
         st.rerun()

--- a/streamlit_app/cache_utils.py
+++ b/streamlit_app/cache_utils.py
@@ -1,12 +1,15 @@
-import os
+import os, streamlit as st
 import requests
-import streamlit as st
 from dotenv import load_dotenv
 from openai import OpenAI
 from urllib.parse import urlencode
 
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com").rstrip("/")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 
 @st.cache_resource
 def get_openai_client() -> OpenAI | None:

--- a/streamlit_app/cookies_utils.py
+++ b/streamlit_app/cookies_utils.py
@@ -1,23 +1,54 @@
-import extra_streamlit_components as stx
-from datetime import datetime, timedelta
 import streamlit as st
+import extra_streamlit_components as stx
+from typing import Optional
 
 
-def get_cm():
+def _get_cookie_manager() -> stx.CookieManager:
+    # Debe existir un único CookieManager "montado" en el árbol de la app
     if "cookie_manager" not in st.session_state:
         st.session_state.cookie_manager = stx.CookieManager()
     return st.session_state.cookie_manager
 
 
-def set_auth_cookies(token, email, days=7):
-    cm = get_cm()
-    expires = (datetime.utcnow() + timedelta(days=days)).strftime("%a, %d %b %Y %H:%M:%S GMT")
-    cm.set("wrapper_token", token, expires=expires, path="/")
-    if email:
-        cm.set("wrapper_email", email, expires=expires, path="/")
+def init_cookie_manager_mount() -> None:
+    """Debe llamarse al inicio de la app para montar el CookieManager."""
+    _get_cookie_manager()
 
 
-def clear_auth_cookies():
-    cm = get_cm()
-    cm.delete("wrapper_token", path="/")
-    cm.delete("wrapper_email", path="/")
+def set_auth_cookies(token: str, email: Optional[str], days: int = 7) -> None:
+    if not token:
+        return
+    cm = _get_cookie_manager()
+    max_age = days * 24 * 3600
+    try:
+        cm.set("wrapper_token", str(token), max_age=max_age, path="/")
+        if email:
+            cm.set("wrapper_email", str(email), max_age=max_age, path="/")
+    except Exception:
+        # No romper la app si el navegador bloquea cookies
+        pass
+
+
+def get_auth_token() -> Optional[str]:
+    cm = _get_cookie_manager()
+    try:
+        return cm.get("wrapper_token")
+    except Exception:
+        return None
+
+
+def get_auth_email() -> Optional[str]:
+    cm = _get_cookie_manager()
+    try:
+        return cm.get("wrapper_email")
+    except Exception:
+        return None
+
+
+def clear_auth_cookies() -> None:
+    cm = _get_cookie_manager()
+    for key in ("wrapper_token", "wrapper_email"):
+        try:
+            cm.delete(key, path="/")
+        except Exception:
+            pass

--- a/streamlit_app/cookies_utils.py
+++ b/streamlit_app/cookies_utils.py
@@ -1,0 +1,23 @@
+import extra_streamlit_components as stx
+from datetime import datetime, timedelta
+import streamlit as st
+
+
+def get_cm():
+    if "cookie_manager" not in st.session_state:
+        st.session_state.cookie_manager = stx.CookieManager()
+    return st.session_state.cookie_manager
+
+
+def set_auth_cookies(token, email, days=7):
+    cm = get_cm()
+    expires = (datetime.utcnow() + timedelta(days=days)).strftime("%a, %d %b %Y %H:%M:%S GMT")
+    cm.set("wrapper_token", token, expires=expires, path="/")
+    if email:
+        cm.set("wrapper_email", email, expires=expires, path="/")
+
+
+def clear_auth_cookies():
+    cm = get_cm()
+    cm.delete("wrapper_token", path="/")
+    cm.delete("wrapper_email", path="/")

--- a/streamlit_app/cookies_utils.py
+++ b/streamlit_app/cookies_utils.py
@@ -21,9 +21,23 @@ def set_auth_cookies(token: str, email: Optional[str], days: int = 7) -> None:
     cm = _get_cookie_manager()
     max_age = days * 24 * 3600
     try:
-        cm.set("wrapper_token", str(token), max_age=max_age, path="/")
+        cm.set(
+            "wrapper_token",
+            str(token),
+            max_age=max_age,
+            path="/",
+            secure=True,
+            same_site="Lax",
+        )
         if email:
-            cm.set("wrapper_email", str(email), max_age=max_age, path="/")
+            cm.set(
+                "wrapper_email",
+                str(email),
+                max_age=max_age,
+                path="/",
+                secure=True,
+                same_site="Lax",
+            )
     except Exception:
         # No romper la app si el navegador bloquea cookies
         pass
@@ -32,7 +46,7 @@ def set_auth_cookies(token: str, email: Optional[str], days: int = 7) -> None:
 def get_auth_token() -> Optional[str]:
     cm = _get_cookie_manager()
     try:
-        return cm.get("wrapper_token")
+        return cm.get("wrapper_token") or None
     except Exception:
         return None
 
@@ -40,7 +54,7 @@ def get_auth_token() -> Optional[str]:
 def get_auth_email() -> Optional[str]:
     cm = _get_cookie_manager()
     try:
-        return cm.get("wrapper_email")
+        return cm.get("wrapper_email") or None
     except Exception:
         return None
 

--- a/streamlit_app/pages/05_Suscripcion.py
+++ b/streamlit_app/pages/05_Suscripcion.py
@@ -1,0 +1,113 @@
+# 05_Suscripcion.py – Página de planes y suscripción
+
+import os, streamlit as st
+import requests
+from auth_utils import ensure_token_and_user, logout_button
+from plan_utils import obtener_plan
+from streamlit_js_eval import streamlit_js_eval
+import streamlit.components.v1 as components
+
+
+def _force_redirect(url: str):
+    st.success("Redirigiendo a Stripe...")
+    st.link_button("👉 Abrir enlace si no se abre automáticamente", url, use_container_width=True)
+    st.session_state['_redir_nonce'] = st.session_state.get('_redir_nonce', 0) + 1
+    try:
+        streamlit_js_eval(
+            js_expressions=f'window.top.location.href="{url}"',
+            key=f"jsredir_{st.session_state.get('_redir_nonce', 0)}",
+        )
+    except Exception:
+        pass
+    components.html(
+        f'''
+        <script>
+        (function() {{
+            try {{ window.top.location.href = "{url}"; }} catch(e) {{}}
+            setTimeout(function() {{ try {{ window.top.location.href = "{url}"; }} catch(e) {{}} }}, 50);
+        }})();
+        </script>
+        ''',
+        height=0,
+    )
+    st.stop()
+
+
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
+
+st.set_page_config(page_title="💳 Suscripción", page_icon="💳")
+logout_button()
+ensure_token_and_user()
+
+price_free = st.secrets.get("STRIPE_PRICE_GRATIS") or os.getenv("STRIPE_PRICE_GRATIS")
+price_basico = st.secrets.get("STRIPE_PRICE_BASICO") or os.getenv("STRIPE_PRICE_BASICO")
+price_premium = st.secrets.get("STRIPE_PRICE_PREMIUM") or os.getenv("STRIPE_PRICE_PREMIUM")
+
+plan = obtener_plan(st.session_state.get("token", ""))
+
+st.title("💳 Suscripción")
+
+col1, col2, col3 = st.columns(3)
+
+with col1:
+    st.subheader("Gratis")
+    st.markdown("- 40 leads/mes\n- 5 mensajes IA\n- Sin exportación CSV")
+    st.button("Elegir Gratis", disabled=(plan == "free"))
+
+with col2:
+    st.subheader("Básico")
+    st.markdown("- Todo lo del Gratis\n- 200 leads/mes\n- Exportación CSV")
+    if st.button("Suscribirme al Básico"):
+        if price_basico:
+            try:
+                r = requests.post(
+                    f"{BACKEND_URL}/crear_portal_pago",
+                    headers={"Authorization": f"Bearer {st.session_state.token}"},
+                    params={"plan": price_basico},
+                    timeout=30,
+                )
+                if r.status_code == 200:
+                    url = r.json().get("url")
+                    if url:
+                        _force_redirect(url)
+                    else:
+                        st.error("La respuesta no contiene URL de Stripe.")
+                else:
+                    st.error("No se pudo iniciar la suscripción.")
+                    st.error(f"Error {r.status_code}: {r.text}")
+            except Exception as e:
+                st.error(f"Error: {e}")
+        else:
+            st.error("Falta configurar el price_id del plan Básico.")
+
+with col3:
+    st.subheader("Premium")
+    st.markdown("- Todo lo del Básico\n- 600 leads/mes\n- Soporte prioritario")
+    if st.button("Suscribirme al Premium"):
+        if price_premium:
+            try:
+                r = requests.post(
+                    f"{BACKEND_URL}/crear_portal_pago",
+                    headers={"Authorization": f"Bearer {st.session_state.token}"},
+                    params={"plan": price_premium},
+                    timeout=30,
+                )
+                if r.status_code == 200:
+                    url = r.json().get("url")
+                    if url:
+                        _force_redirect(url)
+                    else:
+                        st.error("La respuesta no contiene URL de Stripe.")
+                else:
+                    st.error("No se pudo iniciar la suscripción.")
+                    st.error(f"Error {r.status_code}: {r.text}")
+            except Exception as e:
+                st.error(f"Error: {e}")
+        else:
+            st.error("Falta configurar el price_id del plan Premium.")
+
+st.caption("El cobro se gestiona de forma segura en Stripe.")

--- a/streamlit_app/pages/05_Suscripcion.py
+++ b/streamlit_app/pages/05_Suscripcion.py
@@ -3,11 +3,11 @@
 import os, streamlit as st
 import requests
 
+from session_bootstrap import bootstrap
+bootstrap()
+
 from auth_utils import ensure_token_and_user, logout_button
 from plan_utils import obtener_plan, force_redirect
-from cookies_utils import init_cookie_manager_mount
-
-init_cookie_manager_mount()
 
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -5,12 +5,14 @@ import requests
 from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
+
+from session_bootstrap import bootstrap
+bootstrap()
+
 from cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
 from auth_utils import ensure_token_and_user, logout_button
-from cookies_utils import init_cookie_manager_mount, set_auth_cookies
+from cookies_utils import set_auth_cookies
 from plan_utils import obtener_plan, subscription_cta
-
-init_cookie_manager_mount()
 
 load_dotenv()
 BACKEND_URL = (
@@ -55,7 +57,14 @@ def login():
             data = safe_json(r)
             st.session_state.token = data.get("access_token")
             st.session_state.email = email
-            set_auth_cookies(st.session_state.token, st.session_state.get("email"), days=7)
+            try:
+                set_auth_cookies(
+                    st.session_state.token,
+                    st.session_state.get("email"),
+                    days=7,
+                )
+            except Exception:
+                st.warning("No se pudieron guardar las cookies de sesión")
             st.rerun()
         else:
             st.error("Credenciales inválidas")

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -1,8 +1,7 @@
 # 1_Busqueda.py – Página de búsqueda con flujo por pasos, cierre limpio del popup y sugerencias de nicho mejoradas
 
-import streamlit as st
+import os, streamlit as st
 import requests
-import os
 from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
@@ -11,7 +10,11 @@ from sidebar_utils import global_reset_button
 from auth_utils import ensure_token_and_user, logout_button
 
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 st.set_page_config(page_title="Buscar Leads", page_icon="🔎", layout="centered")
 global_reset_button()
 logout_button()

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -7,8 +7,10 @@ from urllib.parse import urlparse
 from json import JSONDecodeError
 from cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
 from auth_utils import ensure_token_and_user, logout_button
-from cookies_utils import set_auth_cookies
+from cookies_utils import init_cookie_manager_mount, set_auth_cookies
 from plan_utils import obtener_plan, subscription_cta
+
+init_cookie_manager_mount()
 
 load_dotenv()
 BACKEND_URL = (

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -6,8 +6,9 @@ from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
 from cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
-from sidebar_utils import global_reset_button
 from auth_utils import ensure_token_and_user, logout_button
+from cookies_utils import set_auth_cookies
+from plan_utils import obtener_plan, subscription_cta
 
 load_dotenv()
 BACKEND_URL = (
@@ -16,7 +17,6 @@ BACKEND_URL = (
     or "https://opensells.onrender.com"
 )
 st.set_page_config(page_title="Buscar Leads", page_icon="🔎", layout="centered")
-global_reset_button()
 logout_button()
 ensure_token_and_user()
 
@@ -44,16 +44,25 @@ def login():
     email = st.text_input("Correo electrónico")
     password = st.text_input("Contraseña", type="password")
     if st.button("Iniciar sesión", key="btn_login"):
-        r = requests.post(f"{BACKEND_URL}/login", data={"username": email, "password": password})
+        r = requests.post(
+            f"{BACKEND_URL}/login",
+            data={"username": email, "password": password},
+            timeout=30,
+        )
         if r.status_code == 200:
             data = safe_json(r)
             st.session_state.token = data.get("access_token")
             st.session_state.email = email
+            set_auth_cookies(st.session_state.token, st.session_state.get("email"), days=7)
             st.rerun()
         else:
             st.error("Credenciales inválidas")
     if st.button("Registrarse", key="btn_register"):
-        r = requests.post(f"{BACKEND_URL}/register", json={"email": email, "password": password})
+        r = requests.post(
+            f"{BACKEND_URL}/register",
+            json={"email": email, "password": password},
+            timeout=30,
+        )
         st.success("Usuario registrado. Ahora inicia sesión." if r.status_code == 200 else "Error al registrar usuario.")
 
 
@@ -81,6 +90,7 @@ plan = obtener_plan(st.session_state.token)
 st.markdown("### 💼 Tu plan actual:")
 if plan == "free":
     st.info("Plan gratuito (free). Algunas funciones están limitadas.")
+    subscription_cta()
 elif plan == "basico":
     st.success("Plan Básico activo. Puedes extraer y exportar leads.")
 elif plan == "premium":
@@ -161,6 +171,7 @@ def procesar_extraccion():
             st.rerun()
         elif r.status_code == 403:
             st.warning("🚫 Tu suscripción no permite extraer leads. Actualiza tu plan para continuar.")
+            subscription_cta()
             st.session_state.loading = False
             return
         else:
@@ -315,6 +326,7 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
             if r_checkout.ok:
                 checkout_url = safe_json(r_checkout).get("url", "")
                 st.warning("🚫 Tu suscripción actual no permite extraer leads.")
+                subscription_cta()
                 st.markdown(f"""
                 <div style='text-align:center; margin-top: 1rem;'>
                     <a href="{checkout_url}" target="_blank" style='
@@ -333,8 +345,10 @@ if st.session_state.get("seleccionadas") and st.button("🔎 Buscar dominios"):
                 """, unsafe_allow_html=True)
             else:
                 st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
+                subscription_cta()
         except Exception:
             st.warning("🚫 Tu suscripción no permite extraer leads. Suscríbete para usar esta función.")
+            subscription_cta()
     else:
         st.session_state.fase_extraccion = "buscando"
         st.session_state.loading = True

--- a/streamlit_app/pages/2_Mis_Nichos.py
+++ b/streamlit_app/pages/2_Mis_Nichos.py
@@ -22,8 +22,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".
 
 from backend.utils import normalizar_nicho
 from cache_utils import cached_get, cached_post, cached_delete, limpiar_cache
-from plan_utils import obtener_plan, tiene_suscripcion_activa
-from sidebar_utils import global_reset_button
+from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
 
 # ── Config ───────────────────────────────────────────
@@ -34,7 +33,6 @@ BACKEND_URL = (
     or "https://opensells.onrender.com"
 )
 st.set_page_config(page_title="Mis Nichos", page_icon="📁")
-global_reset_button()
 logout_button()
 ensure_token_and_user()
 
@@ -175,6 +173,7 @@ for n in nichos_visibles:
         if cols[1].button("🗑️ Eliminar nicho", key=f"del_nicho_{n['nicho']}"):
             if not tiene_suscripcion_activa(plan):
                 st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                subscription_cta()
             else:
                 res = cached_delete("eliminar_nicho", st.session_state.token, params={"nicho": n["nicho"]})
                 if res:
@@ -208,6 +207,7 @@ for n in nichos_visibles:
                 st.warning(
                     "La búsqueda de leads está disponible solo para usuarios con suscripción activa."
                 )
+                subscription_cta()
             else:
                 leads = [
                     l for l in leads
@@ -240,6 +240,7 @@ for n in nichos_visibles:
                         else:
                             if not tiene_suscripcion_activa(plan):
                                 st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                                subscription_cta()
                             else:
                                 res = cached_post(
                                     "añadir_lead_manual",
@@ -274,6 +275,7 @@ for n in nichos_visibles:
             if cols_row[1].button("🗑️", key=f"btn_borrar_{clave_base}"):
                 if not tiene_suscripcion_activa(plan):
                     st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                    subscription_cta()
                 else:
                     res = cached_delete(
                         "eliminar_lead",
@@ -304,6 +306,7 @@ for n in nichos_visibles:
                 if st.button("✅ Confirmar", key=f"confirmar_mover_{clave_base}"):
                     if not tiene_suscripcion_activa(plan):
                         st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                        subscription_cta()
                     else:
                         res = cached_post(
                             "mover_lead",
@@ -340,6 +343,7 @@ for n in nichos_visibles:
                     if st.form_submit_button("💾 Guardar información"):
                         if not tiene_suscripcion_activa(plan):
                             st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                            subscription_cta()
                         else:
                             res = cached_post(
                                 "guardar_info_extra",

--- a/streamlit_app/pages/2_Mis_Nichos.py
+++ b/streamlit_app/pages/2_Mis_Nichos.py
@@ -24,8 +24,10 @@ from backend.utils import normalizar_nicho
 from cache_utils import cached_get, cached_post, cached_delete, limpiar_cache
 from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
+from cookies_utils import init_cookie_manager_mount
 
 # ── Config ───────────────────────────────────────────
+init_cookie_manager_mount()
 load_dotenv()
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")

--- a/streamlit_app/pages/2_Mis_Nichos.py
+++ b/streamlit_app/pages/2_Mis_Nichos.py
@@ -17,6 +17,9 @@ import hashlib
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
+from session_bootstrap import bootstrap
+bootstrap()
+
 # Añadir raíz del proyecto al path para importar correctamente desde backend/
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
@@ -24,10 +27,8 @@ from backend.utils import normalizar_nicho
 from cache_utils import cached_get, cached_post, cached_delete, limpiar_cache
 from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
-from cookies_utils import init_cookie_manager_mount
 
 # ── Config ───────────────────────────────────────────
-init_cookie_manager_mount()
 load_dotenv()
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")

--- a/streamlit_app/pages/2_Mis_Nichos.py
+++ b/streamlit_app/pages/2_Mis_Nichos.py
@@ -11,12 +11,10 @@
 #      reruns innecesarios.
 #   4. Limpieza y tipado ligero.
 
-import os
+import os, streamlit as st
 import sys
 import hashlib
 from urllib.parse import urlparse
-
-import streamlit as st
 from dotenv import load_dotenv
 
 # Añadir raíz del proyecto al path para importar correctamente desde backend/
@@ -30,7 +28,11 @@ from auth_utils import ensure_token_and_user, logout_button
 
 # ── Config ───────────────────────────────────────────
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 st.set_page_config(page_title="Mis Nichos", page_icon="📁")
 global_reset_button()
 logout_button()

--- a/streamlit_app/pages/3_Tareas.py
+++ b/streamlit_app/pages/3_Tareas.py
@@ -7,7 +7,9 @@ from dotenv import load_dotenv
 from cache_utils import cached_get, cached_post, limpiar_cache
 from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
+from cookies_utils import init_cookie_manager_mount
 # ────────────────── Config ──────────────────────────
+init_cookie_manager_mount()
 load_dotenv()
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")

--- a/streamlit_app/pages/3_Tareas.py
+++ b/streamlit_app/pages/3_Tareas.py
@@ -5,8 +5,7 @@ import time
 from datetime import date
 from dotenv import load_dotenv
 from cache_utils import cached_get, cached_post, limpiar_cache
-from plan_utils import obtener_plan, tiene_suscripcion_activa
-from sidebar_utils import global_reset_button
+from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
 # ────────────────── Config ──────────────────────────
 load_dotenv()
@@ -17,7 +16,6 @@ BACKEND_URL = (
 )
 
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
-global_reset_button()
 logout_button()
 ensure_token_and_user()
 
@@ -119,6 +117,7 @@ def render_list(items: list[dict], key_pref: str):
         if cols[5].button("✔️", key=f"done_{unique_key}"):
             if not tiene_suscripcion_activa(plan):
                 st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                subscription_cta()
             else:
                 cached_post("tarea_completada", st.session_state.token, params={"tarea_id": t['id']})
                 limpiar_cache()  # ✅ Añadir esto
@@ -150,6 +149,7 @@ def render_list(items: list[dict], key_pref: str):
             if c4.button("💾", key=f"guardar_edit_{unique_key}"):
                 if not tiene_suscripcion_activa(plan):
                     st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                    subscription_cta()
                 else:
                     cached_post(
                         "editar_tarea",
@@ -207,6 +207,7 @@ elif seccion == titles[1]:
                 if texto.strip():
                     if not tiene_suscripcion_activa(plan):
                         st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                        subscription_cta()
                     else:
                         cached_post(
                             "tarea_lead",
@@ -304,6 +305,7 @@ elif seccion == titles[2]:
                         if texto.strip():
                             if not tiene_suscripcion_activa(plan):
                                 st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                                subscription_cta()
                             else:
                                 cached_post(
                                     "tarea_lead",
@@ -403,6 +405,7 @@ elif seccion == titles[3]:
                     if texto.strip():
                         if not tiene_suscripcion_activa(plan):
                             st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                            subscription_cta()
                         else:
                             cached_post(
                                 "tarea_lead",
@@ -436,6 +439,7 @@ elif seccion == titles[3]:
                 if st.form_submit_button("💾 Guardar información"):
                     if not tiene_suscripcion_activa(plan):
                         st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+                        subscription_cta()
                     else:
                         respuesta = cached_post(
                             "guardar_info_extra",

--- a/streamlit_app/pages/3_Tareas.py
+++ b/streamlit_app/pages/3_Tareas.py
@@ -1,9 +1,8 @@
-import os
+import os, streamlit as st
 from hashlib import md5
 from urllib.parse import urlparse
 import time
 from datetime import date
-import streamlit as st
 from dotenv import load_dotenv
 from cache_utils import cached_get, cached_post, limpiar_cache
 from plan_utils import obtener_plan, tiene_suscripcion_activa
@@ -11,7 +10,11 @@ from sidebar_utils import global_reset_button
 from auth_utils import ensure_token_and_user, logout_button
 # ────────────────── Config ──────────────────────────
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
 global_reset_button()

--- a/streamlit_app/pages/3_Tareas.py
+++ b/streamlit_app/pages/3_Tareas.py
@@ -4,12 +4,14 @@ from urllib.parse import urlparse
 import time
 from datetime import date
 from dotenv import load_dotenv
+
+from session_bootstrap import bootstrap
+bootstrap()
+
 from cache_utils import cached_get, cached_post, limpiar_cache
 from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
-from cookies_utils import init_cookie_manager_mount
 # ────────────────── Config ──────────────────────────
-init_cookie_manager_mount()
 load_dotenv()
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -10,6 +10,7 @@ from json import JSONDecodeError
 from cache_utils import cached_get, cached_post, limpiar_cache
 from sidebar_utils import global_reset_button
 from auth_utils import ensure_token_and_user, logout_button
+from streamlit_js_eval import streamlit_js_eval
 
 load_dotenv()
 BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
@@ -176,18 +177,19 @@ with col1:
                         url = data.get("url")
                         if url:
                             st.success("Redirigiendo a Stripe...")
-                            st.markdown(
-                                f"[Haz clic aquí si no se abre automáticamente]({url})",
-                                unsafe_allow_html=True,
+                            st.link_button(
+                                "👉 Abrir enlace si no se abre automáticamente",
+                                url,
                             )
-                            st.markdown(
-                                f"<meta http-equiv='refresh' content='0; url={url}'>",
-                                unsafe_allow_html=True,
+                            streamlit_js_eval(
+                                js_expressions=f'window.top.location.href="{url}"'
                             )
                         else:
                             st.error("La respuesta no contiene URL de Stripe.")
                 else:
-                    st.error("No se pudo iniciar el pago.")
+                    st.error(
+                        f"No se pudo iniciar el pago (status {r.status_code}): {r.text}"
+                    )
             except Exception as e:
                 st.error(f"Error: {e}")
 
@@ -206,21 +208,15 @@ with col2:
                     url_portal = data.get("url")
                     if url_portal:
                         st.success("Abriendo portal de cliente...")
-                        st.markdown(
-                            f"[👉 Abrir portal de Stripe]({url_portal})",
-                            unsafe_allow_html=True,
-                        )
-                        st.markdown(
-                            f"<meta http-equiv='refresh' content='0; url={url_portal}'>",
-                            unsafe_allow_html=True,
+                        st.link_button("👉 Abrir portal de Stripe", url_portal)
+                        streamlit_js_eval(
+                            js_expressions=f'window.top.location.href="{url_portal}"'
                         )
                     else:
                         st.error("La respuesta no contiene URL del portal.")
                 else:
-                    try:
-                        detalle = r.json().get("detail", "No se pudo abrir el portal del cliente.")
-                    except Exception:
-                        detalle = "No se pudo abrir el portal del cliente."
-                    st.error(detalle)
+                    st.error(
+                        f"No se pudo abrir el portal del cliente (status {r.status_code}): {r.text}"
+                    )
             except Exception as e:
                 st.error(f"Error: {e}")

--- a/streamlit_app/pages/4_Mi_Cuenta.py
+++ b/streamlit_app/pages/4_Mi_Cuenta.py
@@ -1,7 +1,6 @@
 # 4_Mi_Cuenta.py – Página de cuenta de usuario
 
-import streamlit as st
-import os
+import os, streamlit as st
 import requests
 import pandas as pd
 import io
@@ -13,7 +12,11 @@ from auth_utils import ensure_token_and_user, logout_button
 from streamlit_js_eval import streamlit_js_eval
 
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 st.set_page_config(page_title="Mi Cuenta", page_icon="⚙️")
 global_reset_button()
 logout_button()

--- a/streamlit_app/pages/5_Asistente_Virtual.py
+++ b/streamlit_app/pages/5_Asistente_Virtual.py
@@ -3,7 +3,9 @@ from dotenv import load_dotenv
 from cache_utils import cached_get, get_openai_client
 from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
+from cookies_utils import init_cookie_manager_mount
 
+init_cookie_manager_mount()
 st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")  # ✅ PRIMERO
 logout_button()
 ensure_token_and_user()

--- a/streamlit_app/pages/5_Asistente_Virtual.py
+++ b/streamlit_app/pages/5_Asistente_Virtual.py
@@ -1,12 +1,10 @@
 import os, streamlit as st
 from dotenv import load_dotenv
 from cache_utils import cached_get, get_openai_client
-from plan_utils import obtener_plan, tiene_suscripcion_activa
-from sidebar_utils import global_reset_button
+from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
 
 st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")  # ✅ PRIMERO
-global_reset_button()
 logout_button()
 ensure_token_and_user()
 
@@ -48,6 +46,7 @@ pregunta = st.chat_input("Haz una pregunta sobre tus nichos, leads o tareas...")
 if pregunta:
     if not tiene_suscripcion_activa(plan):
         st.warning("Esta funcionalidad está disponible solo para usuarios con suscripción activa.")
+        subscription_cta()
     else:
         st.session_state.chat.append({"role": "user", "content": pregunta})
         with st.chat_message("user"):

--- a/streamlit_app/pages/5_Asistente_Virtual.py
+++ b/streamlit_app/pages/5_Asistente_Virtual.py
@@ -1,5 +1,4 @@
-import streamlit as st
-import os
+import os, streamlit as st
 from dotenv import load_dotenv
 from cache_utils import cached_get, get_openai_client
 from plan_utils import obtener_plan, tiene_suscripcion_activa
@@ -13,7 +12,11 @@ ensure_token_and_user()
 
 # ────────────────── Config ──────────────────────────
 load_dotenv()
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com")
+BACKEND_URL = (
+    st.secrets.get("BACKEND_URL")
+    or os.getenv("BACKEND_URL")
+    or "https://opensells.onrender.com"
+)
 client = get_openai_client()
 
 st.title("🤖 Tu Asistente Virtual")

--- a/streamlit_app/pages/5_Asistente_Virtual.py
+++ b/streamlit_app/pages/5_Asistente_Virtual.py
@@ -1,11 +1,13 @@
 import os, streamlit as st
 from dotenv import load_dotenv
+
+from session_bootstrap import bootstrap
+bootstrap()
+
 from cache_utils import cached_get, get_openai_client
 from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
-from cookies_utils import init_cookie_manager_mount
 
-init_cookie_manager_mount()
 st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")  # ✅ PRIMERO
 logout_button()
 ensure_token_and_user()

--- a/streamlit_app/pages/99_Mi_Cuenta.py
+++ b/streamlit_app/pages/99_Mi_Cuenta.py
@@ -1,4 +1,4 @@
-# 4_Mi_Cuenta.py – Página de cuenta de usuario
+# 99_Mi_Cuenta.py – Página de cuenta de usuario
 
 import os, streamlit as st
 import requests
@@ -8,35 +8,10 @@ from dotenv import load_dotenv
 from json import JSONDecodeError
 from cache_utils import cached_get, cached_post, limpiar_cache
 from auth_utils import ensure_token_and_user, logout_button
-from streamlit_js_eval import streamlit_js_eval
-import streamlit.components.v1 as components
-from plan_utils import subscription_cta
+from plan_utils import subscription_cta, force_redirect
+from cookies_utils import init_cookie_manager_mount
 
-
-def _force_redirect(url: str):
-    st.success("Redirigiendo a Stripe...")
-    st.link_button("👉 Abrir enlace si no se abre automáticamente", url, use_container_width=True)
-    st.session_state['_redir_nonce'] = st.session_state.get('_redir_nonce', 0) + 1
-    try:
-        streamlit_js_eval(
-            js_expressions=f'window.top.location.href="{url}"',
-            key=f"jsredir_{st.session_state.get('_redir_nonce', 0)}",
-        )
-    except Exception:
-        pass
-    components.html(
-        f'''
-        <script>
-        (function() {{
-            try {{ window.top.location.href = "{url}"; }} catch(e) {{}}
-            setTimeout(function() {{ try {{ window.top.location.href = "{url}"; }} catch(e) {{}} }}, 50);
-        }})();
-        </script>
-        ''',
-        height=0,
-    )
-    st.stop()
-
+init_cookie_manager_mount()
 load_dotenv()
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")
@@ -200,7 +175,7 @@ with col1:
                     else:
                         url = data.get("url")
                         if url:
-                            _force_redirect(url)
+                            force_redirect(url)
                         else:
                             st.error("La respuesta no contiene URL de Stripe.")
                 else:
@@ -224,7 +199,7 @@ with col2:
                     data = r.json()
                     url_portal = data.get("url")
                     if url_portal:
-                        _force_redirect(url_portal)
+                        force_redirect(url_portal)
                     else:
                         st.error("La respuesta no contiene URL del portal.")
                 else:

--- a/streamlit_app/pages/99_Mi_Cuenta.py
+++ b/streamlit_app/pages/99_Mi_Cuenta.py
@@ -6,12 +6,14 @@ import pandas as pd
 import io
 from dotenv import load_dotenv
 from json import JSONDecodeError
+
+from session_bootstrap import bootstrap
+bootstrap()
+
 from cache_utils import cached_get, cached_post, limpiar_cache
 from auth_utils import ensure_token_and_user, logout_button
 from plan_utils import subscription_cta, force_redirect
-from cookies_utils import init_cookie_manager_mount
 
-init_cookie_manager_mount()
 load_dotenv()
 BACKEND_URL = (
     st.secrets.get("BACKEND_URL")

--- a/streamlit_app/plan_utils.py
+++ b/streamlit_app/plan_utils.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import time
 import streamlit as st
 from cache_utils import cached_get
+from streamlit_js_eval import streamlit_js_eval
+import streamlit.components.v1 as components
 
 # ---------------------------------------------------------------------------
 # Definición de planes
@@ -104,6 +106,34 @@ def subscription_cta():
         st.markdown("💳 [Ver planes y suscribirme](./05_Suscripcion)")
 
 
+def force_redirect(url: str) -> None:
+    if not url:
+        return
+    st.link_button("👉 Abrir enlace si no se abre automáticamente", url, use_container_width=True)
+    st.session_state["_redir_nonce"] = st.session_state.get("_redir_nonce", 0) + 1
+    try:
+        streamlit_js_eval(
+            js_expressions=f'window.top.location.href="{url}"',
+            key=f"jsredir_{st.session_state['_redir_nonce']}",
+        )
+    except Exception:
+        pass
+    components.html(
+        f"""
+        <script>
+        (function(){{
+          try{{ window.top.location.href = "{url}"; }}catch(e){{}}
+          setTimeout(function(){{
+            try{{ window.top.location.href = "{url}"; }}catch(e){{}}
+          }}, 80);
+        }})();
+        </script>
+        """,
+        height=0,
+    )
+    st.stop()
+
+
 __all__ = [
     "PLANES",
     "obtener_plan",
@@ -111,5 +141,6 @@ __all__ = [
     "obtener_limite",
     "permite_recurso",
     "subscription_cta",
+    "force_redirect",
 ]
 

--- a/streamlit_app/plan_utils.py
+++ b/streamlit_app/plan_utils.py
@@ -97,11 +97,19 @@ def permite_recurso(plan: str, clave: str) -> bool:
     return bool(valor)
 
 
+def subscription_cta():
+    if hasattr(st, "page_link"):
+        st.page_link("pages/05_Suscripcion.py", label="💳 Ver planes y suscribirme")
+    else:
+        st.markdown("💳 [Ver planes y suscribirme](./05_Suscripcion)")
+
+
 __all__ = [
     "PLANES",
     "obtener_plan",
     "tiene_suscripcion_activa",
     "obtener_limite",
     "permite_recurso",
+    "subscription_cta",
 ]
 

--- a/streamlit_app/session_bootstrap.py
+++ b/streamlit_app/session_bootstrap.py
@@ -1,0 +1,7 @@
+import streamlit as st
+from cookies_utils import init_cookie_manager_mount
+
+def bootstrap() -> None:
+    """Initialise components that must run before any auth checks."""
+    init_cookie_manager_mount()
+    st.session_state.setdefault("_bootstrapped", True)


### PR DESCRIPTION
## Summary
- Redirect to Stripe portals using `streamlit_js_eval` instead of meta refresh
- Provide `st.link_button` fallback links for checkout and portal
- Improve error messages with HTTP status code and response text

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_68971a35678083239b9c8f990bebadf6