### PR TITLE
docs: add env setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,16 @@ Este documento refleja el estado actual del proyecto tras todas las mejoras e in
 
 Esto levantará la API en `http://localhost:8000` y la interfaz de Streamlit en `http://localhost:8501`.
 
+### 🔑 Configuración de variables de entorno
+
+Antes de ejecutar los servicios asegúrate de definir tus variables de entorno. El repositorio incluye un archivo de ejemplo que puedes copiar:
+
+```bash
+cp .env.example .env
+```
+
+Completa el archivo `.env` con las credenciales necesarias (PostgreSQL, claves de Stripe, etc.) para que el backend y el frontend funcionen correctamente.
+
 ### 🚀 Próximos pasos sugeridos
 
 - Configurar entorno de test separado (SQLite en memoria o base de datos temporal) para hacer funcionar `pytest`.


### PR DESCRIPTION
## Summary
- document environment variable setup using `.env.example`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6897d337686c8323bc2022e83aaf65e6