### PR TITLE
Handle missing secrets.toml gracefully

### DIFF
--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -1,4 +1,5 @@
-import os, streamlit as st
+import os
+import streamlit as st
 import requests
 from dotenv import load_dotenv
 from cache_utils import limpiar_cache
@@ -9,12 +10,21 @@ from cookies_utils import (
 )
 
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
-ENV = st.secrets.get("ENV") or os.getenv("ENV")
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
+ENV = _safe_secret("ENV")
 
 
 def ensure_token_and_user() -> None:

--- a/streamlit_app/cache_utils.py
+++ b/streamlit_app/cache_utils.py
@@ -1,15 +1,25 @@
-import os, streamlit as st
+import os
+import streamlit as st
 import requests
 from dotenv import load_dotenv
 from openai import OpenAI
 from urllib.parse import urlencode
 
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 @st.cache_resource
 def get_openai_client() -> OpenAI | None:

--- a/streamlit_app/pages/05_Suscripcion.py
+++ b/streamlit_app/pages/05_Suscripcion.py
@@ -1,7 +1,9 @@
 # 05_Suscripcion.py – Página de planes y suscripción
 
-import os, streamlit as st
+import os
+import streamlit as st
 import requests
+from dotenv import load_dotenv
 
 from session_bootstrap import bootstrap
 bootstrap()
@@ -9,19 +11,29 @@ bootstrap()
 from auth_utils import ensure_token_and_user, logout_button
 from plan_utils import obtener_plan, force_redirect
 
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+load_dotenv()
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 st.set_page_config(page_title="💳 Suscripción", page_icon="💳")
 logout_button()
 ensure_token_and_user()
 
-price_free = st.secrets.get("STRIPE_PRICE_GRATIS") or os.getenv("STRIPE_PRICE_GRATIS")
-price_basico = st.secrets.get("STRIPE_PRICE_BASICO") or os.getenv("STRIPE_PRICE_BASICO")
-price_premium = st.secrets.get("STRIPE_PRICE_PREMIUM") or os.getenv("STRIPE_PRICE_PREMIUM")
+price_free = _safe_secret("STRIPE_PRICE_GRATIS")
+price_basico = _safe_secret("STRIPE_PRICE_BASICO")
+price_premium = _safe_secret("STRIPE_PRICE_PREMIUM")
 
 plan = obtener_plan(st.session_state.get("token", ""))
 

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -1,6 +1,7 @@
 # 1_Busqueda.py – Página de búsqueda con flujo por pasos, cierre limpio del popup y sugerencias de nicho mejoradas
 
-import os, streamlit as st
+import os
+import streamlit as st
 import requests
 from dotenv import load_dotenv
 from urllib.parse import urlparse
@@ -15,11 +16,20 @@ from cookies_utils import set_auth_cookies
 from plan_utils import obtener_plan, subscription_cta
 
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Buscar Leads", page_icon="🔎", layout="centered")
 logout_button()
 ensure_token_and_user()

--- a/streamlit_app/pages/2_Mis_Nichos.py
+++ b/streamlit_app/pages/2_Mis_Nichos.py
@@ -11,7 +11,8 @@
 #      reruns innecesarios.
 #   4. Limpieza y tipado ligero.
 
-import os, streamlit as st
+import os
+import streamlit as st
 import sys
 import hashlib
 from urllib.parse import urlparse
@@ -30,11 +31,20 @@ from auth_utils import ensure_token_and_user, logout_button
 
 # ── Config ───────────────────────────────────────────
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mis Nichos", page_icon="📁")
 logout_button()
 ensure_token_and_user()

--- a/streamlit_app/pages/3_Tareas.py
+++ b/streamlit_app/pages/3_Tareas.py
@@ -1,4 +1,5 @@
-import os, streamlit as st
+import os
+import streamlit as st
 from hashlib import md5
 from urllib.parse import urlparse
 import time
@@ -13,11 +14,20 @@ from plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from auth_utils import ensure_token_and_user, logout_button
 # ────────────────── Config ──────────────────────────
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
 logout_button()

--- a/streamlit_app/pages/5_Asistente_Virtual.py
+++ b/streamlit_app/pages/5_Asistente_Virtual.py
@@ -1,4 +1,5 @@
-import os, streamlit as st
+import os
+import streamlit as st
 from dotenv import load_dotenv
 
 from session_bootstrap import bootstrap
@@ -14,11 +15,20 @@ ensure_token_and_user()
 
 # ────────────────── Config ──────────────────────────
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 client = get_openai_client()
 
 st.title("🤖 Tu Asistente Virtual")

--- a/streamlit_app/pages/99_Mi_Cuenta.py
+++ b/streamlit_app/pages/99_Mi_Cuenta.py
@@ -1,6 +1,7 @@
 # 99_Mi_Cuenta.py – Página de cuenta de usuario
 
-import os, streamlit as st
+import os
+import streamlit as st
 import requests
 import pandas as pd
 import io
@@ -15,11 +16,20 @@ from auth_utils import ensure_token_and_user, logout_button
 from plan_utils import subscription_cta, force_redirect
 
 load_dotenv()
-BACKEND_URL = (
-    st.secrets.get("BACKEND_URL")
-    or os.getenv("BACKEND_URL")
-    or "https://opensells.onrender.com"
-)
+
+
+def _safe_secret(name: str, default=None):
+    """Safely retrieve configuration from env or Streamlit secrets."""
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        return st.secrets.get(name, default)
+    except Exception:
+        return default
+
+
+BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mi Cuenta", page_icon="⚙️")
 logout_button()
 ensure_token_and_user()


### PR DESCRIPTION
## Summary
- add `_safe_secret` helper that first reads `os.getenv` then Streamlit `secrets`
- replace direct `st.secrets.get(...)` calls across Streamlit modules
- load `.env` automatically so local env vars work without `secrets.toml`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*


------
https://chatgpt.com/codex/tasks/task_e_689921bcde008323a968f1abdc81ebb1