### PR TITLE
Rebrand landing to OpenSells with feature/benefit copy and CTAs

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,23 +1,67 @@
 """Main entry point for the Streamlit app."""
 
+import os
 import streamlit as st
 from session_bootstrap import bootstrap
 
 bootstrap()
 from auth_utils import ensure_token_and_user, logout_button
 
-st.set_page_config(page_title="Wrapper Leads SaaS", page_icon="🕵️‍♂️")
+st.set_page_config(page_title="OpenSells — tu motor de prospección y leads", page_icon="🧩")
 logout_button()
 ensure_token_and_user()
-st.title("🧠 Wrapper Leads SaaS")
+
+st.title("OpenSells — tu motor de prospección y leads")
 st.markdown(
     """
-Bienvenido a tu plataforma de extracción y gestión de leads.
-Usa el menú lateral para acceder a las siguientes funciones:
+### Bienvenido a OpenSells
+**Tu motor de prospección y leads** para captar clientes desde la web y Google Maps, con IA para enriquecer, clasificar y priorizar.
 
-- Buscar leads y extraer datos automáticamente.
-- Gestionar tus nichos y leads guardados.
-- Ver tareas pendientes.
-- Configurar tu cuenta y estadísticas.
+**Beneficios:**
+- Consigue más leads de calidad en menos tiempo.
+- Centraliza tu prospección: busca, guarda, clasifica y actúa.
+- Evita duplicados entre nichos y mejora el foco de tu equipo.
+- Escala con planes flexibles y paga solo por lo que usas.
+
+**Qué hace OpenSells:**
+- Extracción de leads desde Web y Google Maps (+ IA para enriquecer).
+- Control de duplicados por dominio y aviso si ya existe en otros nichos.
+- Gestión de nichos, tareas y notas por lead.
+- Exportaciones CSV con filtros combinables (dominio, nicho, estado).
+- Buscador global de leads.
+- Planes con Stripe y control de acceso por plan (free, básico, premium).
+- Backend FastAPI + PostgreSQL; Frontend Streamlit.
+
+**Qué puedes hacer ahora mismo:**
 """
 )
+
+suscription_page = "pages/05_Suscripcion.py"
+if not os.path.exists(suscription_page):
+    suscription_page = "pages/99_Mi_Cuenta.py"
+
+try:
+    st.page_link("pages/1_Busqueda.py", label="🔎 Buscar leads ahora", icon="")
+    st.page_link("pages/2_Mis_Nichos.py", label="📁 Ver mis nichos", icon="")
+    st.page_link(suscription_page, label="💳 Activar suscripción", icon="")
+except AttributeError:
+    try:
+        st.link_button("🔎 Buscar leads ahora", "pages/1_Busqueda.py")
+        st.link_button("📁 Ver mis nichos", "pages/2_Mis_Nichos.py")
+        st.link_button("💳 Activar suscripción", suscription_page)
+    except AttributeError:
+        if st.button("🔎 Buscar leads ahora"):
+            try:
+                st.switch_page("pages/1_Busqueda.py")
+            except Exception:
+                pass
+        if st.button("📁 Ver mis nichos"):
+            try:
+                st.switch_page("pages/2_Mis_Nichos.py")
+            except Exception:
+                pass
+        if st.button("💳 Activar suscripción"):
+            try:
+                st.switch_page(suscription_page)
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- rebrand main Streamlit page to OpenSells with new title, benefits and features list
- add CTAs linking to lead search, niches, and subscription pages with fallbacks for page availability

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_6899f29da9e883239e680088d2d7b430