### PR TITLE
Use Streamlit session_state instead of deprecated bootstrap

### DIFF
--- a/streamlit/Home.py
+++ b/streamlit/Home.py
@@ -3,15 +3,13 @@ import streamlit as st
 from requests import ReadTimeout, ConnectTimeout
 from requests.exceptions import ConnectionError
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.auth_utils import ensure_token_and_user, logout_button, save_token
 from streamlit.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from streamlit.cache_utils import cached_get
-from streamlit.cookies_utils import set_auth_cookies
+from streamlit.cookies_utils import set_auth_cookies, init_cookie_manager_mount
 from streamlit.utils import http_client
+
+init_cookie_manager_mount()
 
 st.set_page_config(page_title="OpenSells", page_icon="🧩", layout="wide")
 

--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -3,12 +3,11 @@
 import os
 import streamlit as st
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.auth_utils import ensure_token_and_user, logout_button
+from streamlit.cookies_utils import init_cookie_manager_mount
 from streamlit.utils import http_client
+
+init_cookie_manager_mount()
 
 st.set_page_config(page_title="OpenSells — tu motor de prospección y leads", page_icon="🧩")
 

--- a/streamlit/pages/1_Asistente_Virtual.py
+++ b/streamlit/pages/1_Asistente_Virtual.py
@@ -3,14 +3,13 @@ import json
 import streamlit as st
 from dotenv import load_dotenv
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.cache_utils import cached_get, get_openai_client
 from streamlit.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from streamlit.auth_utils import ensure_token_and_user, logout_button
 from streamlit.utils.http_client import get as http_get, post as http_post, health_ok
+from streamlit.cookies_utils import init_cookie_manager_mount
+
+init_cookie_manager_mount()
 
 st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")
 

--- a/streamlit/pages/2_Busqueda.py
+++ b/streamlit/pages/2_Busqueda.py
@@ -9,13 +9,12 @@ from json import JSONDecodeError
 
 from streamlit.utils import http_client
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
 from streamlit.auth_utils import ensure_token_and_user, logout_button
 from streamlit.plan_utils import subscription_cta
+from streamlit.cookies_utils import init_cookie_manager_mount
+
+init_cookie_manager_mount()
 
 load_dotenv()
 

--- a/streamlit/pages/3_Mis_Nichos.py
+++ b/streamlit/pages/3_Mis_Nichos.py
@@ -17,10 +17,6 @@ import hashlib
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.cache_utils import (
     cached_get,
     cached_post,
@@ -29,7 +25,10 @@ from streamlit.cache_utils import (
 )
 from streamlit.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from streamlit.auth_utils import ensure_token_and_user, logout_button
+from streamlit.cookies_utils import init_cookie_manager_mount
 from streamlit.utils import http_client
+
+init_cookie_manager_mount()
 
 # ── Config ───────────────────────────────────────────
 load_dotenv()

--- a/streamlit/pages/4_Tareas.py
+++ b/streamlit/pages/4_Tareas.py
@@ -6,14 +6,13 @@ import time
 from datetime import date
 from dotenv import load_dotenv
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.cache_utils import cached_get, cached_post, limpiar_cache
 from streamlit.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from streamlit.auth_utils import ensure_token_and_user, logout_button
+from streamlit.cookies_utils import init_cookie_manager_mount
 from streamlit.utils import http_client
+
+init_cookie_manager_mount()
 # ────────────────── Config ──────────────────────────
 load_dotenv()
 

--- a/streamlit/pages/5_Exportaciones.py
+++ b/streamlit/pages/5_Exportaciones.py
@@ -1,10 +1,10 @@
 import streamlit as st
 
-from streamlit.session_bootstrap import bootstrap
 from streamlit.auth_utils import ensure_token_and_user, logout_button
+from streamlit.cookies_utils import init_cookie_manager_mount
 from streamlit.utils import http_client
 
-bootstrap()
+init_cookie_manager_mount()
 
 st.set_page_config(page_title="Exportaciones", page_icon="📤")
 

--- a/streamlit/pages/6_Emails.py
+++ b/streamlit/pages/6_Emails.py
@@ -1,12 +1,11 @@
 import streamlit as st
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from streamlit.auth_utils import ensure_token_and_user, logout_button
+from streamlit.cookies_utils import init_cookie_manager_mount
 from streamlit.utils import http_client
+
+init_cookie_manager_mount()
 
 st.set_page_config(page_title="Emails", page_icon="✉️")
 

--- a/streamlit/pages/7_Suscripcion.py
+++ b/streamlit/pages/7_Suscripcion.py
@@ -5,13 +5,12 @@ import streamlit as st
 import requests
 from dotenv import load_dotenv
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.auth_utils import ensure_token_and_user, logout_button
 from streamlit.utils import http_client
 from streamlit.plan_utils import obtener_plan, force_redirect
+from streamlit.cookies_utils import init_cookie_manager_mount
+
+init_cookie_manager_mount()
 
 load_dotenv()
 

--- a/streamlit/pages/8_Mi_Cuenta.py
+++ b/streamlit/pages/8_Mi_Cuenta.py
@@ -8,14 +8,13 @@ import io
 from dotenv import load_dotenv
 from json import JSONDecodeError
 
-from streamlit.session_bootstrap import bootstrap
-
-bootstrap()
-
 from streamlit.cache_utils import cached_get, cached_post, limpiar_cache
 from streamlit.auth_utils import ensure_token_and_user, logout_button
 from streamlit.utils import http_client
 from streamlit.plan_utils import subscription_cta, force_redirect
+from streamlit.cookies_utils import init_cookie_manager_mount
+
+init_cookie_manager_mount()
 
 load_dotenv()
 

--- a/streamlit/session_bootstrap.py
+++ b/streamlit/session_bootstrap.py
@@ -1,8 +1,0 @@
-import streamlit as st
-
-from streamlit.cookies_utils import init_cookie_manager_mount
-
-def bootstrap() -> None:
-    """Initialise components that must run before any auth checks."""
-    init_cookie_manager_mount()
-    st.session_state.setdefault("_bootstrapped", True)


### PR DESCRIPTION
## Summary
- replace legacy `session_bootstrap` imports with `init_cookie_manager_mount`
- drop custom `session_bootstrap` module and rely on public `st.session_state`
- ensure all modules reference the `streamlit` package path

## Testing
- `pytest` *(fails: assert 401 == 200)*
- `timeout 15 streamlit run streamlit/Home.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_689c69e3b2ac83239b0811a6b7e5b9ca