### PR TITLE
Fix Streamlit app imports and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install -r requirements.txt
 uvicorn backend.main:app --reload
 ```
 
-3. Inicia el frontend:
+3. Inicia el frontend desde la raíz del proyecto:
 
 ```bash
 streamlit run streamlit_app/Home.py

--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -1,13 +1,19 @@
-import pathlib
 import streamlit as st
 from requests import ReadTimeout, ConnectTimeout
 from requests.exceptions import ConnectionError
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button, save_token
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.cache_utils import cached_get
-from streamlit_app.cookies_utils import set_auth_cookies, init_cookie_manager_mount
-from streamlit_app.utils import http_client
+# --- ensure project root on sys.path (fallback for Streamlit working-dir quirks)
+import sys
+from pathlib import Path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from .auth_utils import ensure_token_and_user, logout_button, save_token
+from .plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
+from .cache_utils import cached_get
+from .cookies_utils import set_auth_cookies, init_cookie_manager_mount
+from .utils import http_client
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -3,9 +3,9 @@
 import os
 import streamlit as st
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
+from .auth_utils import ensure_token_and_user, logout_button
+from .cookies_utils import init_cookie_manager_mount
+from .utils import http_client
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/1_Asistente_Virtual.py
+++ b/streamlit_app/pages/1_Asistente_Virtual.py
@@ -3,11 +3,11 @@ import json
 import streamlit as st
 from dotenv import load_dotenv
 
-from streamlit_app.cache_utils import cached_get, get_openai_client
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.utils.http_client import get as http_get, post as http_post, health_ok
-from streamlit_app.cookies_utils import init_cookie_manager_mount
+from ..cache_utils import cached_get, get_openai_client
+from ..plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..utils.http_client import get as http_get, post as http_post, health_ok
+from ..cookies_utils import init_cookie_manager_mount
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/2_Busqueda.py
+++ b/streamlit_app/pages/2_Busqueda.py
@@ -7,12 +7,12 @@ from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
 
-from streamlit_app.utils import http_client
+from ..utils import http_client
 
-from streamlit_app.cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.plan_utils import subscription_cta
-from streamlit_app.cookies_utils import init_cookie_manager_mount
+from ..cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..plan_utils import subscription_cta
+from ..cookies_utils import init_cookie_manager_mount
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -17,16 +17,16 @@ import hashlib
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
-from streamlit_app.cache_utils import (
+from ..cache_utils import (
     cached_get,
     cached_post,
     cached_delete,
     limpiar_cache,
 )
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
+from ..plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..cookies_utils import init_cookie_manager_mount
+from ..utils import http_client
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/4_Tareas.py
+++ b/streamlit_app/pages/4_Tareas.py
@@ -6,11 +6,11 @@ import time
 from datetime import date
 from dotenv import load_dotenv
 
-from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
+from ..cache_utils import cached_get, cached_post, limpiar_cache
+from ..plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..cookies_utils import init_cookie_manager_mount
+from ..utils import http_client
 
 init_cookie_manager_mount()
 # ────────────────── Config ──────────────────────────

--- a/streamlit_app/pages/5_Exportaciones.py
+++ b/streamlit_app/pages/5_Exportaciones.py
@@ -1,8 +1,8 @@
 import streamlit as st
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..cookies_utils import init_cookie_manager_mount
+from ..utils import http_client
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/6_Emails.py
+++ b/streamlit_app/pages/6_Emails.py
@@ -1,9 +1,9 @@
 import streamlit as st
 
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
+from ..plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..cookies_utils import init_cookie_manager_mount
+from ..utils import http_client
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/7_Suscripcion.py
+++ b/streamlit_app/pages/7_Suscripcion.py
@@ -5,10 +5,10 @@ import streamlit as st
 import requests
 from dotenv import load_dotenv
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.utils import http_client
-from streamlit_app.plan_utils import obtener_plan, force_redirect
-from streamlit_app.cookies_utils import init_cookie_manager_mount
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..utils import http_client
+from ..plan_utils import obtener_plan, force_redirect
+from ..cookies_utils import init_cookie_manager_mount
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/pages/8_Mi_Cuenta.py
+++ b/streamlit_app/pages/8_Mi_Cuenta.py
@@ -8,11 +8,11 @@ import io
 from dotenv import load_dotenv
 from json import JSONDecodeError
 
-from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
-from streamlit_app.utils import http_client
-from streamlit_app.plan_utils import subscription_cta, force_redirect
-from streamlit_app.cookies_utils import init_cookie_manager_mount
+from ..cache_utils import cached_get, cached_post, limpiar_cache
+from ..auth_utils import ensure_token_and_user, logout_button
+from ..utils import http_client
+from ..plan_utils import subscription_cta, force_redirect
+from ..cookies_utils import init_cookie_manager_mount
 
 init_cookie_manager_mount()
 

--- a/streamlit_app/plan_utils.py
+++ b/streamlit_app/plan_utils.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import time
 import streamlit as st
 
-from streamlit_app.cache_utils import cached_get
+from .cache_utils import cached_get
 from streamlit_js_eval import streamlit_js_eval
 import streamlit.components.v1 as components
 

--- a/streamlit_app/sidebar_utils.py
+++ b/streamlit_app/sidebar_utils.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from streamlit_app.cache_utils import limpiar_cache
+from .cache_utils import limpiar_cache
 
 def global_reset_button():
     """Render a sidebar button to clear cache and rerun the app."""


### PR DESCRIPTION
## Summary
- use package-relative imports across `streamlit_app`
- add sys.path fallback in `Home.py` for Streamlit working-dir quirks
- document running the frontend from repository root

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH="$(pwd)" streamlit run streamlit_app/Home.py`

------
https://chatgpt.com/codex/tasks/task_e_689d06f241f883238b18f2efb3a3f816