### PR TITLE
refactor: unify session management and path handling

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import sessionmaker, declarative_base
 import os
 from dotenv import load_dotenv
 from pathlib import Path
+import pathlib
 
 # ✅ Cargar archivo .env manualmente desde la raíz del proyecto
 dotenv_path = Path(__file__).resolve().parents[1] / ".env"

--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -5,26 +5,25 @@ from requests.exceptions import ConnectionError
 # --- Ensure project root is in sys.path
 import sys
 from pathlib import Path
+import pathlib
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button, save_token
+from streamlit_app.auth_utils import get_session_user, logout_button, save_token
 from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
 from streamlit_app.cache_utils import cached_get
 from streamlit_app.cookies_utils import set_auth_cookies, init_cookie_manager_mount
 from streamlit_app.utils import http_client
+from streamlit_app.common_paths import APP_DIR, PAGES_DIR
 
 init_cookie_manager_mount()
 
 st.set_page_config(page_title="OpenSells", page_icon="🧩", layout="wide")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
+token, user = get_session_user(require_auth=False)
 
 st.markdown("### ✨ Opensells")
 st.markdown(
@@ -114,9 +113,6 @@ if not user:
     st.stop()
 
 logout_button()
-
-APP_DIR = pathlib.Path(__file__).parent
-PAGES_DIR = APP_DIR / "pages"
 
 
 def page_exists(name: str) -> bool:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -3,6 +3,8 @@
 # --- Ensure project root is in sys.path
 import sys
 from pathlib import Path
+import pathlib
+
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -10,23 +12,15 @@ if str(ROOT) not in sys.path:
 import os
 import streamlit as st
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
 
 init_cookie_manager_mount()
 
 st.set_page_config(page_title="OpenSells — tu motor de prospección y leads", page_icon="🧩")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 

--- a/streamlit_app/auth_utils.py
+++ b/streamlit_app/auth_utils.py
@@ -1,40 +1,62 @@
 from __future__ import annotations
 
-from typing import Callable, Optional, Tuple
+"""Helpers de autenticación y sesión."""
+
+from typing import Optional, Tuple
 
 import streamlit as st
 
+from streamlit_app.utils import http_client
+
 
 def save_token(token: Optional[str]) -> None:
-    """Store token in the current session state."""
+    """Guarda el token en el ``session_state`` actual."""
     if token:
         st.session_state["token"] = token
 
 
 def logout_button(label: str = "Cerrar sesión") -> None:
-    """Render a logout button in the sidebar that clears the token."""
+    """Muestra un botón en la barra lateral que limpia el token."""
     if st.sidebar.button(label):
         if "token" in st.session_state:
             del st.session_state["token"]
         st.rerun()
 
 
-def ensure_token_and_user(
-    api_me: Callable[[str], dict | None]
-) -> Tuple[dict | None, str | None]:
-    """Return user and token if a valid session exists.
-
-    The token is read from ``st.session_state``. If present, ``api_me`` is called
-    with the token to retrieve user information. Any error or missing data
-    results in ``(None, None)`` without raising exceptions.
-    """
+def ensure_token_and_user() -> Tuple[dict | None, str | None]:
+    """Devuelve ``(user, token)`` si existe una sesión válida."""
     token = st.session_state.get("token")
     if not token:
         return None, None
+
     try:
-        user = api_me(token)
+        resp = http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
+        if resp.status_code != 200:
+            return None, None
+        user = resp.json()
+        st.session_state["user"] = user
+        return user, token
     except Exception:
         return None, None
-    if not user:
-        return None, None
-    return user, token
+
+
+def get_session_user(require_auth: bool = True) -> Tuple[Optional[str], Optional[dict]]:
+    """Obtiene ``(token, user)`` desde ``st.session_state`` o intenta restaurarlos.
+
+    Si ``require_auth`` es ``True`` y no hay usuario, se informa al usuario y se
+    detiene la ejecución de la página.
+    """
+    token = st.session_state.get("token")
+    user = st.session_state.get("user")
+
+    if not user or not token:
+        try:
+            user, token = ensure_token_and_user()
+        except Exception:
+            token, user = None, None
+
+    if require_auth and not user:
+        st.info("Por favor, inicia sesión en la página **Home** para continuar.")
+        st.stop()
+
+    return token, user

--- a/streamlit_app/common_paths.py
+++ b/streamlit_app/common_paths.py
@@ -1,0 +1,6 @@
+from pathlib import Path
+import pathlib
+
+APP_DIR = Path(__file__).resolve().parent
+ROOT_DIR = APP_DIR.parent
+PAGES_DIR = APP_DIR / "pages"

--- a/streamlit_app/pages/1_Asistente_Virtual.py
+++ b/streamlit_app/pages/1_Asistente_Virtual.py
@@ -4,8 +4,8 @@ import streamlit as st
 from dotenv import load_dotenv
 
 from streamlit_app.cache_utils import cached_get, get_openai_client
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.utils.http_client import get as http_get, post as http_post, health_ok
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 
@@ -14,14 +14,7 @@ init_cookie_manager_mount()
 st.set_page_config(page_title="Asistente Virtual", page_icon="🤖")
 
 
-def api_me(token: str):
-    return http_get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 
@@ -54,7 +47,7 @@ st.write(
 )
 st.divider()
 
-plan = obtener_plan(st.session_state.token)
+plan = (user or {}).get("plan", "free")
 
 
 def _auth_headers():

--- a/streamlit_app/pages/2_Busqueda.py
+++ b/streamlit_app/pages/2_Busqueda.py
@@ -10,7 +10,7 @@ from json import JSONDecodeError
 from streamlit_app.utils import http_client
 
 from streamlit_app.cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.plan_utils import subscription_cta
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 
@@ -22,14 +22,7 @@ BACKEND_URL = http_client.BACKEND_URL
 st.set_page_config(page_title="Buscar Leads", page_icon="🔎", layout="centered")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 plan = (user or {}).get("plan", "free")
 

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -23,8 +23,8 @@ from streamlit_app.cache_utils import (
     cached_delete,
     limpiar_cache,
 )
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 from streamlit_app.utils import http_client
 
@@ -49,14 +49,8 @@ BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mis Nichos", page_icon="📁")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
+plan = (user or {}).get("plan", "free")
 
 logout_button()
 
@@ -78,9 +72,6 @@ def normalizar_dominio(url: str) -> str:
 
 def md5(s: str) -> str:
     return hashlib.md5(s.encode()).hexdigest()
-
-# ── Protección de acceso ─────────────────────────────
-plan = obtener_plan(st.session_state.token)
 
 # ── Forzar Recarga Caché ─────────────────────────────
 if "forzar_recarga" not in st.session_state:

--- a/streamlit_app/pages/4_Tareas.py
+++ b/streamlit_app/pages/4_Tareas.py
@@ -7,8 +7,8 @@ from datetime import date
 from dotenv import load_dotenv
 
 from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 from streamlit_app.utils import http_client
 
@@ -33,18 +33,11 @@ BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 
-plan = obtener_plan(st.session_state.token)
+plan = (user or {}).get("plan", "free")
 
 # Validar el token llamando a un endpoint protegido. Si falla, forzamos logout
 validacion = cached_get("protegido", st.session_state.token, nocache_key=time.time())

--- a/streamlit_app/pages/5_Exportaciones.py
+++ b/streamlit_app/pages/5_Exportaciones.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 from streamlit_app.utils import http_client
 
@@ -9,14 +9,7 @@ init_cookie_manager_mount()
 st.set_page_config(page_title="Exportaciones", page_icon="📤")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 

--- a/streamlit_app/pages/6_Emails.py
+++ b/streamlit_app/pages/6_Emails.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
-from streamlit_app.plan_utils import obtener_plan, tiene_suscripcion_activa, subscription_cta
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 from streamlit_app.utils import http_client
 
@@ -10,18 +10,11 @@ init_cookie_manager_mount()
 st.set_page_config(page_title="Emails", page_icon="✉️")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 
-plan = obtener_plan(st.session_state.token)
+plan = (user or {}).get("plan", "free")
 
 st.title("✉️ Emails")
 st.info("Funcionalidad de envío de emails — Disponible próximamente.")

--- a/streamlit_app/pages/7_Suscripcion.py
+++ b/streamlit_app/pages/7_Suscripcion.py
@@ -5,9 +5,9 @@ import streamlit as st
 import requests
 from dotenv import load_dotenv
 
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.utils import http_client
-from streamlit_app.plan_utils import obtener_plan, force_redirect
+from streamlit_app.plan_utils import force_redirect
 from streamlit_app.cookies_utils import init_cookie_manager_mount
 
 init_cookie_manager_mount()
@@ -31,14 +31,7 @@ BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="💳 Suscripción", page_icon="💳")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 
@@ -46,7 +39,7 @@ price_free = _safe_secret("STRIPE_PRICE_GRATIS")
 price_basico = _safe_secret("STRIPE_PRICE_BASICO")
 price_premium = _safe_secret("STRIPE_PRICE_PREMIUM")
 
-plan = obtener_plan(st.session_state.token)
+plan = (user or {}).get("plan", "free")
 
 st.title("💳 Suscripción")
 

--- a/streamlit_app/pages/8_Mi_Cuenta.py
+++ b/streamlit_app/pages/8_Mi_Cuenta.py
@@ -1,15 +1,15 @@
 # 8_Mi_Cuenta.py – Página de cuenta de usuario
 
 import os
-import streamlit as st
 import requests
 import pandas as pd
 import io
+import streamlit as st
 from dotenv import load_dotenv
 from json import JSONDecodeError
 
 from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
-from streamlit_app.auth_utils import ensure_token_and_user, logout_button
+from streamlit_app.auth_utils import get_session_user, logout_button
 from streamlit_app.utils import http_client
 from streamlit_app.plan_utils import subscription_cta, force_redirect
 from streamlit_app.cookies_utils import init_cookie_manager_mount
@@ -34,14 +34,7 @@ BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mi Cuenta", page_icon="⚙️")
 
 
-def api_me(token: str):
-    return http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
-
-
-user, token = ensure_token_and_user(api_me)
-if user is None or token is None:
-    st.error("No se pudo validar la sesión. Inicia sesión de nuevo.")
-    st.stop()
+token, user = get_session_user(require_auth=True)
 
 logout_button()
 


### PR DESCRIPTION
## Summary
- add central `get_session_user` helper and refresh `ensure_token_and_user`
- standardize pages to bootstrap session via `get_session_user`
- fix missing `pathlib` imports and share common path constants

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `streamlit run streamlit_app/Home.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_689d14b0e2e88323907943460fae3021