### PR TITLE
Normaliza email y añade herramientas de depuración de nichos/leads

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -3,6 +3,7 @@ from jose import jwt, JWTError
 from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.future import select
+from sqlalchemy import func
 from backend.models import Usuario
 from backend.database import get_db
 from sqlalchemy.orm import Session
@@ -40,7 +41,8 @@ def crear_token(data: dict):
 
 
 def obtener_usuario_por_email(email: str, db: Session):
-    return db.query(Usuario).filter(Usuario.email == email).first()
+    email = (email or "").strip().lower()
+    return db.query(Usuario).filter(func.lower(Usuario.email) == email).first()
 
 def get_current_user(token: str | None = Depends(oauth2_scheme), db: Session = Depends(get_db)):
     """Obtiene el usuario actual a partir de un token JWT.
@@ -67,6 +69,7 @@ def get_current_user(token: str | None = Depends(oauth2_scheme), db: Session = D
         email = payload.get("sub")
         if email is None:
             raise credentials_exc
+        email = email.strip().lower()
         user = obtener_usuario_por_email(email, db)
         if user is None:
             raise credentials_exc

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,6 +38,9 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Flag de diagnóstico temporal
+DEBUG_DIAGNOSTICO = os.getenv("DEBUG_DIAGNOSTICO") == "1"
+
 import stripe
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
 # Dominio al que Stripe debe redirigir tras finalizar o cancelar el proceso
@@ -102,6 +105,15 @@ def health():
 
 @app.on_event("startup")
 async def startup():
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL no está definida")
+        raise RuntimeError("DATABASE_URL no está definida")
+    if db_url.startswith("sqlite"):
+        logger.error("DATABASE_URL apunta a SQLite: %s", db_url)
+        raise RuntimeError("DATABASE_URL debe usar PostgreSQL")
+    logger.warning("DATABASE_URL prefix: %s", db_url[:16])
+    logger.warning("SQLAlchemy engine: %s", engine.url)
     Base.metadata.create_all(bind=engine)
     crear_tablas_si_no_existen()  # ✅ función síncrona, se llama normal
 
@@ -152,10 +164,11 @@ from sqlalchemy.orm import Session  # asegúrate de tener este import arriba
 
 @app.post("/register")
 def register(user: UsuarioRegistro, db: Session = Depends(get_db)):
-    db_user = obtener_usuario_por_email(user.email, db)
+    email = user.email.strip().lower()
+    db_user = obtener_usuario_por_email(email, db)
     if db_user:
         raise HTTPException(status_code=400, detail="El usuario ya existe")
-    nuevo_usuario = Usuario(email=user.email, hashed_password=hashear_password(user.password))
+    nuevo_usuario = Usuario(email=email, hashed_password=hashear_password(user.password))
     db.add(nuevo_usuario)
     db.commit()
     return {"mensaje": "Usuario registrado correctamente"}
@@ -164,7 +177,8 @@ from sqlalchemy.orm import Session  # asegúrate de tener este import en la part
 
 @app.post("/login")
 def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
-    user = obtener_usuario_por_email(form_data.username, db)
+    email = form_data.username.strip().lower()
+    user = obtener_usuario_por_email(email, db)
     if not user or not verificar_password(form_data.password, user.hashed_password):
         raise HTTPException(status_code=401, detail="Credenciales inválidas")
     token = crear_token({"sub": user.email})
@@ -177,7 +191,7 @@ def usuario_actual(usuario=Depends(get_current_user)):
     """Devuelve los datos básicos del usuario autenticado."""
     return {
         "id": usuario.id,
-        "email": usuario.email,
+        "email": usuario.email.lower(),
         "plan": usuario.plan or "free",
         "fecha_creacion": usuario.fecha_creacion.isoformat() if usuario.fecha_creacion else None,
     }
@@ -185,8 +199,8 @@ def usuario_actual(usuario=Depends(get_current_user)):
 @app.get("/protegido")
 async def protegido(usuario = Depends(get_current_user)):
     return {
-        "mensaje": f"Bienvenido, {usuario.email}",
-        "email": usuario.email,
+        "mensaje": f"Bienvenido, {usuario.email.lower()}",
+        "email": usuario.email.lower(),
         "plan": usuario.plan or "free"
     }
 
@@ -212,7 +226,7 @@ async def generar_variantes_cliente_ideal(
 
     # 1. Si no hay contexto manual ni forzar_variantes, intenta cargar memoria automáticamente
     if not forzar_variantes and not contexto_extra:
-        memoria = obtener_memoria_usuario(usuario.email)
+        memoria = obtener_memoria_usuario(usuario.email.lower())
         if memoria:
             contexto_extra = f"El usuario indicó esto sobre su negocio: {memoria}"
 
@@ -412,11 +426,11 @@ def exportar_csv(payload: ExportarCSVRequest, usuario = Depends(validar_suscripc
 
     # ✅ Guardar en base de datos solo dominios nuevos
     from backend.db import obtener_todos_los_dominios_usuario
-    dominios_guardados = obtener_todos_los_dominios_usuario(usuario.email, db)
+    dominios_guardados = obtener_todos_los_dominios_usuario(usuario.email.lower(), db)
     dominios_guardados_normalizados = set(normalizar_dominio(d) for d in dominios_guardados)
     nuevos_dominios = [d for d in dominios_unicos if normalizar_dominio(d) not in dominios_guardados_normalizados]
 
-    guardar_leads_extraidos(usuario.email, nuevos_dominios, nicho_normalizado, nicho_original, db)
+    guardar_leads_extraidos(usuario.email.lower(), nuevos_dominios, nicho_normalizado, nicho_original, db)
 
     # Ya no se mantiene un CSV global. Solo se guardan en la base de datos.
 
@@ -431,27 +445,48 @@ def exportar_csv(payload: ExportarCSVRequest, usuario = Depends(validar_suscripc
 # 📜 Historial de exportaciones
 @app.get("/historial")
 def ver_historial(usuario = Depends(get_current_user)):
-    historial = obtener_historial(usuario.email)
+    historial = obtener_historial(usuario.email.lower())
     return {"historial": historial}
 
 # 📂 Ver nichos del usuario
 @app.get("/mis_nichos")
 def mis_nichos(usuario=Depends(get_current_user), db: Session = Depends(get_db)):
-    nichos = obtener_nichos_usuario(usuario.email, db)
+    email = usuario.email.lower()
+    nichos = obtener_nichos_usuario(email, db)
+    if DEBUG_DIAGNOSTICO:
+        logger.info("/mis_nichos email=%s count=%d", email, len(nichos))
     return {"nichos": nichos}
 
 # 🔍 Ver leads por nicho
 @app.get("/leads_por_nicho")
 def leads_por_nicho(nicho: str, usuario = Depends(get_current_user), db: Session = Depends(get_db)):
-    nicho = normalizar_nicho(nicho)
-    leads = obtener_leads_por_nicho(usuario.email, nicho, db)
-    return {"nicho": nicho, "leads": leads}
+    email = usuario.email.lower()
+    nicho_original = nicho
+    nicho_norm = normalizar_nicho(nicho)
+    leads = obtener_leads_por_nicho(email, nicho_norm, db)
+    if DEBUG_DIAGNOSTICO:
+        logger.info(
+            "/leads_por_nicho email=%s nicho=%s nicho_norm=%s count=%d",
+            email,
+            nicho_original,
+            nicho_norm,
+            len(leads),
+        )
+        if not leads:
+            logger.warning(
+                "/leads_por_nicho sin resultados email=%s nicho=%s nicho_norm=%s",
+                email,
+                nicho_original,
+                nicho_norm,
+            )
+    return {"nicho": nicho_norm, "leads": leads}
 
 @app.get("/exportar_leads_nicho")
 def exportar_leads_nicho(nicho: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     start = perf_counter()
+    email = usuario.email.lower()
     nicho_norm = normalizar_nicho(nicho)
-    leads = obtener_leads_por_nicho(usuario.email, nicho_norm, db)
+    leads = obtener_leads_por_nicho(email, nicho_norm, db)
 
     if not leads:
         raise HTTPException(status_code=404, detail="No hay leads para exportar")
@@ -484,7 +519,7 @@ def eliminar_nicho_usuario(
     db: Session = Depends(get_db)
 ):
     nicho = normalizar_nicho(nicho)
-    eliminar_nicho_postgres(usuario.email, nicho, db)
+    eliminar_nicho_postgres(usuario.email.lower(), nicho, db)
     return {"mensaje": f"Nicho '{nicho}' eliminado correctamente"}
 
 # ✅ Filtrar URLs repetidas por nicho
@@ -495,7 +530,7 @@ class FiltrarUrlsRequest(BaseModel):
 @app.post("/filtrar_urls")
 def filtrar_urls(payload: FiltrarUrlsRequest, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     payload.nicho = normalizar_nicho(payload.nicho)
-    urls_guardadas = obtener_urls_extraidas_por_nicho(usuario.email, payload.nicho, db)
+    urls_guardadas = obtener_urls_extraidas_por_nicho(usuario.email.lower(), payload.nicho, db)
 
     dominios_guardados = set(extraer_dominio_base(url) for url in urls_guardadas)
     urls_filtradas = [url for url in payload.urls if extraer_dominio_base(url) not in dominios_guardados]
@@ -509,7 +544,7 @@ def exportar_todos_mis_leads(usuario=Depends(get_current_user), db: Session = De
 
     leads = (
         db.query(LeadExtraido)
-        .filter(LeadExtraido.user_email == usuario.email)
+        .filter(LeadExtraido.user_email == usuario.email.lower())
         .order_by(LeadExtraido.timestamp.desc())
         .all()
     )
@@ -530,7 +565,7 @@ def exportar_todos_mis_leads(usuario=Depends(get_current_user), db: Session = De
     df_total.to_csv(buffer, index=False, encoding="utf-8-sig")
     buffer.seek(0)
 
-    nombre_archivo = f"leads_totales_{usuario.email}.csv"
+    nombre_archivo = f"leads_totales_{usuario.email.lower()}.csv"
     logger.info(
         "exportar_todos_mis_leads %d leads en %.2fs", len(df_total), perf_counter() - start
     )
@@ -546,9 +581,9 @@ from sqlalchemy.orm import Session  # asegúrate de tener este import
 def guardar_estado(payload: EstadoDominioRequest, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     try:
         url = normalizar_dominio(payload.dominio.strip())
-        logger.info(f"Recibido estado='{payload.estado}' para URL='{url}' por usuario='{usuario.email}'")
-        guardar_estado_lead(usuario.email, url, payload.estado.strip(), db)
-        guardar_evento_historial(usuario.email, url, "estado", f"Estado cambiado a '{payload.estado}'", db)
+        logger.info(f"Recibido estado='{payload.estado}' para URL='{url}' por usuario='{usuario.email.lower()}'")
+        guardar_estado_lead(usuario.email.lower(), url, payload.estado.strip(), db)
+        guardar_evento_historial(usuario.email.lower(), url, "estado", f"Estado cambiado a '{payload.estado}'", db)
         return {"mensaje": "Estado actualizado"}
     except Exception as e:
         logger.error(f"ERROR al guardar estado: {str(e)}")
@@ -557,13 +592,13 @@ def guardar_estado(payload: EstadoDominioRequest, usuario=Depends(get_current_us
 @app.get("/estado_lead")
 def obtener_estado(dominio: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     url = normalizar_dominio(dominio)
-    estado = obtener_estado_lead(usuario.email, url, db)
+    estado = obtener_estado_lead(usuario.email.lower(), url, db)
     return {"estado": estado or "nuevo"}
 
 @app.get("/nichos_de_dominio")
 def nichos_de_dominio(dominio: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     dominio_base = extraer_dominio_base(dominio)
-    nichos = obtener_nichos_para_url(usuario.email, dominio_base, db)
+    nichos = obtener_nichos_para_url(usuario.email.lower(), dominio_base, db)
     return {"nichos": nichos}
 
 from sqlalchemy.orm import Session
@@ -580,8 +615,8 @@ def guardar_nota(payload: NotaDominioRequest, usuario=Depends(get_current_user),
     from backend.db import guardar_nota_lead_postgres as guardar_nota_lead
     try:
         dominio_base = normalizar_dominio(payload.dominio.strip())
-        guardar_nota_lead(usuario.email, dominio_base, payload.nota.strip(), db)
-        guardar_evento_historial(usuario.email, dominio_base, "nota", "Nota actualizada", db)
+        guardar_nota_lead(usuario.email.lower(), dominio_base, payload.nota.strip(), db)
+        guardar_evento_historial(usuario.email.lower(), dominio_base, "nota", "Nota actualizada", db)
         return {"mensaje": "Nota guardada"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error al guardar nota: {str(e)}")
@@ -590,11 +625,11 @@ def guardar_nota(payload: NotaDominioRequest, usuario=Depends(get_current_user),
 def obtener_nota(dominio: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     from backend.db import obtener_nota_lead_postgres as obtener_nota_lead
     dominio_base = normalizar_dominio(dominio)
-    nota = obtener_nota_lead(usuario.email, dominio_base, db)
+    nota = obtener_nota_lead(usuario.email.lower(), dominio_base, db)
 
     # Guardar en log
     with open("log_nota_lead.txt", "a", encoding="utf-8") as f:
-        f.write(f"[{datetime.now()}] Email: {usuario.email} - Dominio: {dominio_base} - Nota encontrada: '{nota}'\n")
+        f.write(f"[{datetime.now()}] Email: {usuario.email.lower()} - Dominio: {dominio_base} - Nota encontrada: '{nota}'\n")
 
     return {"nota": nota or ""}
 
@@ -610,14 +645,14 @@ def guardar_info_extra_api(data: InfoExtraRequest, usuario=Depends(get_current_u
 
     dominio = normalizar_dominio(data.dominio.strip())
     guardar_info_extra(
-        user_email=usuario.email,
+        user_email=usuario.email.lower(),
         dominio=dominio,
         email=data.email.strip(),
         telefono=data.telefono.strip(),
         informacion=data.informacion.strip(),
         db=db
     )
-    guardar_evento_historial(usuario.email, dominio, "info", "Información extra guardada o actualizada", db)
+    guardar_evento_historial(usuario.email.lower(), dominio, "info", "Información extra guardada o actualizada", db)
     return {"mensaje": "Información guardada correctamente"}
 
 @app.get("/info_extra")
@@ -625,12 +660,12 @@ def obtener_info_extra_api(dominio: str, usuario=Depends(get_current_user), db: 
     from backend.db import obtener_info_extra_postgres as obtener_info_extra
 
     dominio = normalizar_dominio(dominio)
-    info = obtener_info_extra(usuario.email, dominio, db)
+    info = obtener_info_extra(usuario.email.lower(), dominio, db)
     return info
 
 @app.get("/buscar_leads")
 def buscar_leads(query: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
-    resultados = buscar_leads_global_postgres(usuario.email, query, db)
+    resultados = buscar_leads_global_postgres(usuario.email.lower(), query, db)
     return {"resultados": resultados}
 
 from pydantic import BaseModel
@@ -651,7 +686,7 @@ from backend.db import obtener_tareas_lead_postgres as obtener_tareas_lead
 @app.post("/tarea_lead")
 def agregar_tarea(payload: TareaRequest, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     guardar_tarea_lead(
-        email=usuario.email,
+        email=usuario.email.lower(),
         texto=payload.texto.strip(),
         fecha=payload.fecha,
         dominio=payload.dominio.strip() if payload.dominio else None,
@@ -664,7 +699,7 @@ def agregar_tarea(payload: TareaRequest, usuario=Depends(get_current_user), db: 
     # 📌 GUARDAR HISTORIAL SI ES TAREA GENERAL O POR NICHO
     if not payload.dominio:
         guardar_evento_historial(
-            usuario.email,
+            usuario.email.lower(),
             dominio="general" if payload.tipo == "general" else payload.nicho,
             tipo=payload.tipo,
             descripcion=f"Tarea añadida: {payload.texto}",
@@ -674,7 +709,7 @@ def agregar_tarea(payload: TareaRequest, usuario=Depends(get_current_user), db: 
     # 🧠 GUARDAR HISTORIAL SI ES TAREA POR LEAD
     if payload.dominio:
         guardar_evento_historial(
-            usuario.email,
+            usuario.email.lower(),
             payload.dominio,
             "tarea",
             f"Tarea añadida: {payload.texto}",
@@ -686,21 +721,21 @@ def agregar_tarea(payload: TareaRequest, usuario=Depends(get_current_user), db: 
 
 @app.get("/tareas_lead")
 def ver_tareas(dominio: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
-    tareas = obtener_tareas_lead(usuario.email, normalizar_dominio(dominio), db)
+    tareas = obtener_tareas_lead(usuario.email.lower(), normalizar_dominio(dominio), db)
     return {"tareas": tareas}
 
 @app.post("/tarea_completada")
 def completar_tarea(tarea_id: int, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
-    marcar_tarea_completada(usuario.email, tarea_id, db)
+    marcar_tarea_completada(usuario.email.lower(), tarea_id, db)
 
-    tarea = obtener_tarea_por_id(usuario.email, tarea_id, db)
+    tarea = obtener_tarea_por_id(usuario.email.lower(), tarea_id, db)
 
     if tarea:
         tipo = tarea.get("tipo")
         texto = tarea.get("texto")
         if tipo == "lead":
             guardar_evento_historial(
-                usuario.email,
+                usuario.email.lower(),
                 tarea["dominio"],
                 tipo="tarea",
                 descripcion=f"Tarea completada: {texto}",
@@ -708,7 +743,7 @@ def completar_tarea(tarea_id: int, usuario=Depends(get_current_user), db: Sessio
             )
         elif tipo == "nicho":
             guardar_evento_historial(
-                usuario.email,
+                usuario.email.lower(),
                 tarea["nicho"],
                 tipo="nicho",
                 descripcion=f"Tarea completada: {texto}",
@@ -716,7 +751,7 @@ def completar_tarea(tarea_id: int, usuario=Depends(get_current_user), db: Sessio
             )
         elif tipo == "general":
             guardar_evento_historial(
-                usuario.email,
+                usuario.email.lower(),
                 "general",
                 tipo="general",
                 descripcion=f"Tarea completada: {texto}",
@@ -728,9 +763,9 @@ def completar_tarea(tarea_id: int, usuario=Depends(get_current_user), db: Sessio
 @app.post("/editar_tarea")
 def editar_tarea(tarea_id: int, payload: TareaRequest, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     from backend.db import editar_tarea_existente_postgres as editar_tarea_existente
-    editar_tarea_existente(usuario.email, tarea_id, payload, db)
+    editar_tarea_existente(usuario.email.lower(), tarea_id, payload, db)
     guardar_evento_historial(
-        usuario.email,
+        usuario.email.lower(),
         payload.dominio or payload.nicho or "general",
         "tarea",
         f"Tarea editada: {payload.texto}",
@@ -740,18 +775,18 @@ def editar_tarea(tarea_id: int, payload: TareaRequest, usuario=Depends(get_curre
 
 @app.get("/tareas_pendientes")
 def tareas_pendientes(usuario=Depends(get_current_user), db: Session = Depends(get_db)):
-    tareas = obtener_todas_tareas_pendientes(usuario.email, db)
+    tareas = obtener_todas_tareas_pendientes(usuario.email.lower(), db)
     return {"tareas": tareas}
 
 @app.get("/historial_lead")
 def historial_lead(dominio: str, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
-    eventos = obtener_historial_por_dominio(usuario.email, normalizar_dominio(dominio), db)
+    eventos = obtener_historial_por_dominio(usuario.email.lower(), normalizar_dominio(dominio), db)
     return {"historial": eventos}
 
 @app.post("/mi_memoria")
 def guardar_memoria(request: MemoriaUsuarioRequest, usuario=Depends(get_current_user)):
     try:
-        guardar_memoria_usuario(usuario.email, request.descripcion.strip())
+        guardar_memoria_usuario(usuario.email.lower(), request.descripcion.strip())
         return {"mensaje": "Memoria guardada correctamente"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error al guardar memoria: {str(e)}")
@@ -759,7 +794,7 @@ def guardar_memoria(request: MemoriaUsuarioRequest, usuario=Depends(get_current_
 @app.get("/mi_memoria")
 def obtener_memoria(usuario=Depends(get_current_user)):
     try:
-        memoria = obtener_memoria_usuario(usuario.email)
+        memoria = obtener_memoria_usuario(usuario.email.lower())
         return {"memoria": memoria or ""}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error al obtener memoria: {str(e)}")
@@ -771,9 +806,9 @@ def historial_tareas(tipo: str = "general", nicho: str = None, usuario=Depends(g
     from backend.db import obtener_historial_por_tipo_postgres as obtener_historial_por_tipo, obtener_historial_por_nicho_postgres as obtener_historial_por_nicho
 
     if tipo == "nicho" and nicho:
-        historial = obtener_historial_por_nicho(usuario.email, nicho, db)
+        historial = obtener_historial_por_nicho(usuario.email.lower(), nicho, db)
     else:
-        historial = obtener_historial_por_tipo(usuario.email, tipo, db)
+        historial = obtener_historial_por_tipo(usuario.email.lower(), tipo, db)
 
     return {"historial": historial}
 
@@ -811,7 +846,7 @@ def añadir_lead_manual(request: LeadManualRequest, usuario=Depends(validar_susc
         dominio_normalizado = normalizar_dominio(dominio)
 
         # Comprobar duplicados globales
-        existentes = obtener_todos_los_dominios_usuario(usuario.email, db)
+        existentes = obtener_todos_los_dominios_usuario(usuario.email.lower(), db)
         existentes_normalizados = set(normalizar_dominio(d) for d in existentes)
 
         if dominio_normalizado in existentes_normalizados:
@@ -819,7 +854,7 @@ def añadir_lead_manual(request: LeadManualRequest, usuario=Depends(validar_susc
 
         # Guardar en base de datos
         guardar_leads_extraidos(
-            usuario.email,
+            usuario.email.lower(),
             [dominio],
             normalizar_nicho(request.nicho),
             request.nicho,
@@ -866,7 +901,7 @@ def importar_csv_manual(nicho: str, archivo: UploadFile, usuario=Depends(validar
 
     df_nuevo = pd.DataFrame(filas)
 
-    guardar_leads_extraidos(usuario.email, list(dominios), normalizar_nicho(nicho), nicho, db)
+    guardar_leads_extraidos(usuario.email.lower(), list(dominios), normalizar_nicho(nicho), nicho, db)
 
     return {"mensaje": f"Se han importado {len(dominios)} leads correctamente."}
 
@@ -886,7 +921,7 @@ def mover_lead(request: MoverLeadRequest, usuario=Depends(get_current_user), db:
 
     # Actualizar en base de datos
     mover_lead_en_bd(
-        user_email=usuario.email,
+        user_email=usuario.email.lower(),
         dominio_original=request.dominio.strip(),
         nicho_origen=normalizar_nicho(request.origen),
         nicho_destino=normalizar_nicho(request.destino),
@@ -909,14 +944,14 @@ def editar_nicho(request: EditarNichoRequest, usuario=Depends(get_current_user),
     from backend.db import editar_nombre_nicho, guardar_evento_historial
     try:
         editar_nombre_nicho(
-            email=usuario.email,
+            email=usuario.email.lower(),
             nicho_actual=request.nicho_actual,
             nuevo_nombre=request.nuevo_nombre,
             db=db
         )
 
         guardar_evento_historial(
-            email=usuario.email,
+            email=usuario.email.lower(),
             dominio="nicho",
             tipo="nicho",
             descripcion=f"Nicho renombrado de '{request.nicho_actual}' a '{request.nuevo_nombre}'",
@@ -944,16 +979,16 @@ def eliminar_lead(
 
         # 🧪 Log inicial
         with open("log_eliminar_lead.txt", "a", encoding="utf-8") as f:
-            f.write(f"[{datetime.now()}] Inicio eliminación — Email: {usuario.email} — Dominio: {dominio_base} — Solo este nicho: {solo_de_este_nicho} — Nicho: {nicho}\n")
+            f.write(f"[{datetime.now()}] Inicio eliminación — Email: {usuario.email.lower()} — Dominio: {dominio_base} — Solo este nicho: {solo_de_este_nicho} — Nicho: {nicho}\n")
 
         if solo_de_este_nicho:
             if not nicho:
                 raise HTTPException(status_code=400, detail="Debes especificar el nicho.")
-            eliminar_lead_de_nicho(usuario.email, dominio_base, normalizar_nicho(nicho), db)
+            eliminar_lead_de_nicho(usuario.email.lower(), dominio_base, normalizar_nicho(nicho), db)
         else:
-            eliminar_lead_completamente(usuario.email, dominio_base, db)
+            eliminar_lead_completamente(usuario.email.lower(), dominio_base, db)
 
-        guardar_evento_historial(usuario.email, dominio_base, "lead", "Lead eliminado", db)
+        guardar_evento_historial(usuario.email.lower(), dominio_base, "lead", "Lead eliminado", db)
 
 
         return {"mensaje": "Lead eliminado correctamente"}
@@ -980,7 +1015,7 @@ def crear_checkout(
             if coupon_id:
                 discounts = [{"coupon": coupon_id}]
         checkout = stripe.checkout.Session.create(
-            customer_email=usuario.email,
+            customer_email=usuario.email.lower(),
             payment_method_types=["card"],
             line_items=[{
                 "price": plan,
@@ -1005,7 +1040,7 @@ def crear_portal_pago(
 ):
     """Crea una sesión de Checkout o Customer Portal según corresponda."""
     try:
-        customers = stripe.Customer.list(email=usuario.email).data
+        customers = stripe.Customer.list(email=usuario.email.lower()).data
         if customers:
             session = stripe.billing_portal.Session.create(
                 customer=customers[0].id,
@@ -1026,7 +1061,7 @@ def crear_portal_pago(
                 discounts = [{"coupon": coupon_id}]
 
         checkout = stripe.checkout.Session.create(
-            customer_email=usuario.email,
+            customer_email=usuario.email.lower(),
             payment_method_types=["card"],
             line_items=[{"price": plan, "quantity": 1}],
             mode="subscription",
@@ -1046,7 +1081,7 @@ def crear_portal_cliente(usuario=Depends(get_current_user)):
     """Genera una sesión del portal de facturación de Stripe para que el
     usuario pueda gestionar su suscripción."""
     try:
-        customers = stripe.Customer.list(email=usuario.email).data
+        customers = stripe.Customer.list(email=usuario.email.lower()).data
         if not customers or not customers[0].id:
             raise HTTPException(
                 status_code=400,
@@ -1097,9 +1132,28 @@ async def stripe_webhook(request: Request):
 
     return {"status": "ok"}
 
-from fastapi import Request
 import os
 
 @app.get("/debug-db")
-def debug_db(request: Request):
-    return {"DATABASE_URL": os.getenv("DATABASE_URL")}
+def debug_db():
+    db_url = os.getenv("DATABASE_URL") or ""
+    return {"database_url": db_url, "engine": str(engine.url)}
+
+@app.get("/debug-user-snapshot")
+def debug_user_snapshot(usuario=Depends(get_current_user), db: Session = Depends(get_db)):
+    db_url = os.getenv("DATABASE_URL") or ""
+    email = usuario.email.lower()
+    nichos = obtener_nichos_usuario(email, db)
+    muestra = [n["nicho"] for n in nichos[:5]]
+    leads_total = (
+        db.query(LeadExtraido)
+        .filter(LeadExtraido.user_email == email)
+        .count()
+    )
+    return {
+        "email_me": email,
+        "db_url_prefix": db_url[:16],
+        "nichos_count": len(nichos),
+        "muestra_nichos": muestra,
+        "leads_count_total": leads_total,
+    }

--- a/backend/scripts/migrate_emails_lowercase.py
+++ b/backend/scripts/migrate_emails_lowercase.py
@@ -1,0 +1,18 @@
+from sqlalchemy import text
+from backend.database import engine
+
+TABLE_COLUMNS = {
+    "lead_extraido": "user_email",
+    "lead_tarea": "email",
+    "lead_historial": "email",
+    "lead_nota": "email",
+    "lead_info_extra": "user_email",
+}
+
+def main():
+    with engine.begin() as conn:
+        for table, column in TABLE_COLUMNS.items():
+            conn.execute(text(f"UPDATE {table} SET {column} = LOWER({column})"))
+
+if __name__ == "__main__":
+    main()

--- a/streamlit_app/pages/8_Mi_Cuenta.py
+++ b/streamlit_app/pages/8_Mi_Cuenta.py
@@ -175,9 +175,23 @@ with col1:
             except Exception as e:
                 st.error(f"Error: {e}")
 
-with st.expander("Depurar sesión"):
+with st.expander("Debug sesión/DB"):
     st.write("Token (prefijo):", (st.session_state.get("token") or "")[:12])
     st.write("Usuario:", st.session_state.get("user"))
+    try:
+        dbg_db = requests.get(f"{BACKEND_URL}/debug-db").json()
+    except Exception:
+        dbg_db = {}
+    try:
+        dbg_snapshot = requests.get(
+            f"{BACKEND_URL}/debug-user-snapshot", headers=headers
+        ).json()
+    except Exception:
+        dbg_snapshot = {}
+    st.write("Email /me:", dbg_snapshot.get("email_me"))
+    st.write("DB URL prefix:", (dbg_db.get("database_url") or "")[:16])
+    st.write("# Nichos:", dbg_snapshot.get("nichos_count"))
+    st.write("# Leads:", dbg_snapshot.get("leads_count_total"))
 
 with col2:
     if plan not in ["basico", "premium"]:


### PR DESCRIPTION
## Resumen
- Normaliza correos en autenticación y en uso general
- Agrega logs y endpoint `/debug-user-snapshot` para diagnosticar nichos/leads y DB
- Añade bloque de debug en la página *Mi Cuenta* y script de migración de emails

## Testing
- `python -m py_compile backend/main.py backend/auth.py streamlit_app/pages/8_Mi_Cuenta.py backend/scripts/migrate_emails_lowercase.py`
- `ALLOW_ANON_USER=1 pytest` *(falla: cambios de API provocan 4 tests con 200 esperado)*

------
https://chatgpt.com/codex/tasks/task_e_68a65430644c8323a1a89b3de3fcc487