### PR TITLE
Ensure backend auth on Nichos and Tareas pages

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -42,7 +42,7 @@ def crear_token(data: dict):
 
 def obtener_usuario_por_email(email: str, db: Session):
     email = (email or "").strip().lower()
-    return db.query(Usuario).filter(func.lower(Usuario.email) == email).first()
+    return db.query(Usuario).filter(Usuario.email_lower == email).first()
 
 def get_current_user(token: str | None = Depends(oauth2_scheme), db: Session = Depends(get_db)):
     """Obtiene el usuario actual a partir de un token JWT.

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -6,6 +6,7 @@ from sqlalchemy.future import select
 from sqlalchemy import func
 from backend.models import Usuario
 from backend.database import get_db
+from backend.utils import normalizar_email
 from sqlalchemy.orm import Session
 import os
 
@@ -41,7 +42,7 @@ def crear_token(data: dict):
 
 
 def obtener_usuario_por_email(email: str, db: Session):
-    email = (email or "").strip().lower()
+    email = normalizar_email(email)
     return db.query(Usuario).filter(Usuario.email_lower == email).first()
 
 def get_current_user(token: str | None = Depends(oauth2_scheme), db: Session = Depends(get_db)):
@@ -71,7 +72,7 @@ def get_current_user(token: str | None = Depends(oauth2_scheme), db: Session = D
         email = payload.get("sub")
         if email is None:
             raise credentials_exc
-        email = email.strip().lower()
+        email = normalizar_email(email)
         user = obtener_usuario_por_email(email, db)
         if user is None:
             raise credentials_exc

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,29 +1,44 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
 import os
-from dotenv import load_dotenv
 from pathlib import Path
-import pathlib
 
-# ✅ Cargar archivo .env manualmente desde la raíz del proyecto
-dotenv_path = Path(__file__).resolve().parents[1] / ".env"
-load_dotenv(dotenv_path=dotenv_path)
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Load environment variables as early as possible
+load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
 
 DATABASE_URL = os.getenv("DATABASE_URL")
-
 if not DATABASE_URL:
-    raise ValueError("❌ DATABASE_URL no está definido. Verifica tu archivo .env")
+    raise ValueError("❌ DATABASE_URL no está definido. Verifica tu configuración")
 
-# ✅ Crear engine síncrono
-engine = create_engine(DATABASE_URL, echo=True)
+url = make_url(DATABASE_URL)
+connect_args = {}
+engine_kwargs = {"pool_pre_ping": True}
 
-SessionLocal = sessionmaker(
-    bind=engine,
-    autoflush=False,
-    autocommit=False
-)
+if url.drivername.startswith("sqlite"):
+    # In-memory or file-based SQLite for local/tests
+    connect_args["check_same_thread"] = False
+    engine_kwargs["connect_args"] = connect_args
+    engine_kwargs["poolclass"] = StaticPool
+else:
+    # Assume PostgreSQL/Render deployment
+    if "sslmode" not in url.query:
+        connect_args["sslmode"] = "require"
+    engine_kwargs.update(
+        {
+            "pool_size": int(os.getenv("DB_POOL_SIZE", "5")),
+            "max_overflow": int(os.getenv("DB_MAX_OVERFLOW", "10")),
+            "connect_args": connect_args,
+        }
+    )
 
+engine = create_engine(url, **engine_kwargs)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
+
 
 def get_db():
     db = SessionLocal()
@@ -31,3 +46,14 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+def db_info() -> dict:
+    """Return a summary of the current DB configuration."""
+    return {
+        "driver": url.drivername,
+        "host": url.host,
+        "database": url.database,
+        "sslmode": connect_args.get("sslmode") or url.query.get("sslmode"),
+    }
+

--- a/backend/database.py
+++ b/backend/database.py
@@ -6,6 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import declarative_base, sessionmaker
 from sqlalchemy.pool import StaticPool
+from sqlalchemy import inspect, text
 
 # Load environment variables as early as possible
 load_dotenv(dotenv_path=Path(__file__).resolve().parents[1] / ".env")
@@ -56,4 +57,63 @@ def db_info() -> dict:
         "database": url.database,
         "sslmode": connect_args.get("sslmode") or url.query.get("sslmode"),
     }
+
+
+def bootstrap_database():
+    """Idempotent database fixes for production (adds columns/constraints)."""
+    if url.drivername.startswith("sqlite"):
+        return
+    with engine.begin() as conn:
+        inspector = inspect(conn)
+        # usuarios.email_lower
+        cols = {c["name"] for c in inspector.get_columns("usuarios")}
+        if "email_lower" not in cols:
+            conn.execute(text("ALTER TABLE usuarios ADD COLUMN email_lower VARCHAR"))
+        conn.execute(text(
+            "UPDATE usuarios SET email_lower = LOWER(TRIM(email)) WHERE email_lower IS NULL OR email_lower = ''"
+        ))
+        conn.execute(text("ALTER TABLE usuarios ALTER COLUMN email_lower SET NOT NULL"))
+        ucs = {uc["name"] for uc in inspector.get_unique_constraints("usuarios")}
+        if "ux_usuarios_email_lower" not in ucs:
+            conn.execute(text(
+                "ALTER TABLE usuarios ADD CONSTRAINT ux_usuarios_email_lower UNIQUE (email_lower)"
+            ))
+        # plan column default/backfill
+        if "plan" not in cols:
+            conn.execute(text("ALTER TABLE usuarios ADD COLUMN plan VARCHAR DEFAULT 'free'"))
+        else:
+            conn.execute(text("ALTER TABLE usuarios ALTER COLUMN plan SET DEFAULT 'free'"))
+        conn.execute(text("UPDATE usuarios SET plan='free' WHERE plan IS NULL OR plan=''"))
+        conn.execute(text("ALTER TABLE usuarios ALTER COLUMN plan SET NOT NULL"))
+
+        # Ensure user_email_lower columns and uniqueness
+        table_sources = {
+            "nichos": ("email", "uq_user_nicho", "nicho"),
+            "leads_extraidos": ("user_email", "uq_user_url", "url"),
+            "lead_tarea": ("email", None, None),
+            "lead_historial": ("email", None, None),
+            "lead_info_extra": ("user_email", None, None),
+            "suscripciones": (None, None, None),
+        }
+        for table, (src, uq_name, uq_col) in table_sources.items():
+            if table not in inspector.get_table_names():
+                continue
+            tcols = {c["name"] for c in inspector.get_columns(table)}
+            if "user_email_lower" not in tcols:
+                conn.execute(text(f"ALTER TABLE {table} ADD COLUMN user_email_lower VARCHAR"))
+                if src and src in tcols:
+                    conn.execute(text(
+                        f"UPDATE {table} SET user_email_lower = LOWER(TRIM({src})) WHERE user_email_lower IS NULL"
+                    ))
+                conn.execute(text(f"ALTER TABLE {table} ALTER COLUMN user_email_lower SET NOT NULL"))
+            idxs = {idx["name"] for idx in inspector.get_indexes(table)}
+            idx_name = f"ix_{table}_user_email_lower"
+            if idx_name not in idxs:
+                conn.execute(text(f"CREATE INDEX {idx_name} ON {table}(user_email_lower)"))
+            if uq_name and uq_col:
+                uexisting = {uc["name"] for uc in inspector.get_unique_constraints(table)}
+                if uq_name not in uexisting:
+                    conn.execute(text(
+                        f"ALTER TABLE {table} ADD CONSTRAINT {uq_name} UNIQUE (user_email_lower, {uq_col})"
+                    ))
 

--- a/backend/db.py
+++ b/backend/db.py
@@ -12,6 +12,7 @@ Base = declarative_base()
 from sqlalchemy import func
 import sqlite3
 from datetime import datetime
+from backend.utils import normalizar_dominio
 
 DB_PATH = "backend/historial.db"
 
@@ -616,21 +617,10 @@ def eliminar_lead_de_nicho(user_email: str, dominio: str, nicho: str, db: Sessio
     ).delete()
     db.commit()
 
-from urllib.parse import urlparse
-
-def extraer_dominio_base(url: str) -> str:
-    if not url:
-        return ""
-    if url.startswith("http://") or url.startswith("https://"):
-        dominio = urlparse(url).netloc
-        return dominio.replace("www.", "").strip()
-    else:
-        return url.replace("www.", "").strip()
-
 def mover_lead_en_bd(user_email: str, dominio_original: str, nicho_origen: str, nicho_destino: str, nicho_original_destino: str, db: Session):
     from backend.models import LeadExtraido, LeadTarea
 
-    dominio_limpio = extraer_dominio_base(dominio_original)
+    dominio_limpio = normalizar_dominio(dominio_original)
 
     # 🗑️ Eliminar del nicho original
     email_lower = (user_email or "").strip().lower()
@@ -652,21 +642,9 @@ def mover_lead_en_bd(user_email: str, dominio_original: str, nicho_origen: str, 
 
     db.commit()
 
-from urllib.parse import urlparse
-
-def normalizar_dominio(url: str) -> str:
-    if not url:
-        return ""
-    url = url.lower().strip()
-    if url.startswith("http://") or url.startswith("https://"):
-        dominio = urlparse(url).netloc
-    else:
-        dominio = urlparse("http://" + url).netloc
-    dominio = dominio.replace("www.", "").strip()
-    return dominio.split("/")[0]  # Elimina todo lo que haya después de /
 
 def editar_nombre_nicho(email: str, nicho_actual: str, nuevo_nombre: str):
-    from .main import normalizar_nicho
+    from backend.utils import normalizar_nicho
     with sqlite3.connect(DB_PATH) as db:
         db.execute("""
             UPDATE leads_extraidos

--- a/backend/main.py
+++ b/backend/main.py
@@ -1205,6 +1205,11 @@ def debug_user_snapshot(
             )
             .count()
         )
+        leads_sin_dominio = (
+            db.query(LeadExtraido)
+            .filter((LeadExtraido.dominio == None) | (LeadExtraido.dominio == ""))
+            .count()
+        )
         leads_sin_nicho = (
             db.query(LeadExtraido)
             .filter((LeadExtraido.nicho == None) | (LeadExtraido.nicho == ""))
@@ -1227,6 +1232,7 @@ def debug_user_snapshot(
                 "nichos_sin_user_email_lower": nichos_sin_user,
                 "leads_sin_user_email_lower": leads_sin_user,
                 "leads_sin_nicho": leads_sin_nicho,
+                "leads_sin_dominio": leads_sin_dominio,
             },
         }
     except Exception as e:

--- a/backend/models.py
+++ b/backend/models.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import validates
 
 from backend.database import Base
+from backend.utils import normalizar_dominio
 
 
 # Tabla de usuarios
@@ -124,19 +125,25 @@ class LeadExtraido(Base):
     id = Column(Integer, primary_key=True)
     user_email = Column(String, nullable=False)
     user_email_lower = Column(String, index=True, nullable=False)
-    url = Column(String, nullable=False)
+    url = Column(String, nullable=True)
+    dominio = Column(String, nullable=False)
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
     nicho = Column(String, nullable=False)  # Normalizado
     nicho_original = Column(String, nullable=False)
 
     __table_args__ = (
-        UniqueConstraint("user_email_lower", "url", name="uq_user_url"),
+        UniqueConstraint("user_email_lower", "dominio", name="uq_user_dominio"),
     )
 
     @validates("user_email")
     def _set_lower(self, key, value):
         self.user_email_lower = (value or "").strip().lower()
         return (value or "").strip()
+
+    @validates("url")
+    def _set_dominio(self, key, value):
+        self.dominio = normalizar_dominio(value)
+        return value
 
 
 class Suscripcion(Base):

--- a/backend/models.py
+++ b/backend/models.py
@@ -22,7 +22,7 @@ class Usuario(Base):
     email_lower = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     fecha_creacion = Column(DateTime(timezone=True), server_default=func.now())
-    plan = Column(String, default="free")
+    plan = Column(String, default="free", nullable=False)
 
     @validates("email")
     def _set_lower(self, key, value):
@@ -50,7 +50,7 @@ class LeadTarea(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, nullable=False)
-    user_email_lower = Column(String, index=True)
+    user_email_lower = Column(String, index=True, nullable=False)
     dominio = Column(String)
     texto = Column(Text, nullable=False)
     fecha = Column(String)
@@ -72,7 +72,7 @@ class LeadHistorial(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     email = Column(String, nullable=False)
-    user_email_lower = Column(String, index=True)
+    user_email_lower = Column(String, index=True, nullable=False)
     dominio = Column(String, nullable=False)
     tipo = Column(String, nullable=False)
     descripcion = Column(Text, nullable=False)
@@ -89,7 +89,7 @@ class LeadNota(Base):
 
     id = Column(Integer, primary_key=True)
     email = Column(String, nullable=False)
-    email_lower = Column(String, index=True)
+    email_lower = Column(String, index=True, nullable=False)
     url = Column(String, nullable=False)
     nota = Column(Text, nullable=True)
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
@@ -109,7 +109,7 @@ class LeadInfoExtra(Base):
     telefono = Column(String)
     informacion = Column(Text)
     user_email = Column(String)
-    user_email_lower = Column(String, index=True)
+    user_email_lower = Column(String, index=True, nullable=False)
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
 
     @validates("user_email")

--- a/backend/scripts/sql_verificacion.sql
+++ b/backend/scripts/sql_verificacion.sql
@@ -1,0 +1,16 @@
+-- Sustituye :email_lower por el correo del usuario en minúsculas
+SELECT * FROM usuarios WHERE email_lower = :email_lower;
+
+SELECT nicho, nicho_original, COUNT(*) AS leads
+FROM leads_extraidos
+WHERE user_email_lower = :email_lower
+GROUP BY nicho, nicho_original
+ORDER BY leads DESC;
+
+SELECT COUNT(*) FROM lead_tarea WHERE user_email_lower = :email_lower AND completado = false;
+
+SELECT status, current_period_end
+FROM suscripciones
+WHERE user_email_lower = :email_lower
+ORDER BY current_period_end DESC
+LIMIT 1;

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,8 +1,26 @@
 import unicodedata
 import re
+from urllib.parse import urlparse
+
+
+def normalizar_email(email: str) -> str:
+    return (email or "").strip().lower()
+
 
 def normalizar_nicho(texto: str) -> str:
     texto = texto.strip().lower()
     texto = unicodedata.normalize('NFKD', texto).encode('ASCII', 'ignore').decode('utf-8')
     texto = re.sub(r'[^a-z0-9]+', '_', texto)
     return texto.strip('_')
+
+
+def normalizar_dominio(url: str) -> str:
+    if not url:
+        return ""
+    url = url.lower().strip()
+    if url.startswith("http://") or url.startswith("https://"):
+        dominio = urlparse(url).netloc
+    else:
+        dominio = urlparse("http://" + url).netloc
+    dominio = dominio.replace("www.", "").strip()
+    return dominio.split("/")[0]

--- a/streamlit_app/pages/1_Asistente_Virtual.py
+++ b/streamlit_app/pages/1_Asistente_Virtual.py
@@ -22,20 +22,6 @@ if st.sidebar.button("Cerrar sesión"):
 
 # ────────────────── Config ──────────────────────────
 load_dotenv()
-
-
-def _safe_secret(name: str, default=None):
-    """Safely retrieve configuration from env or Streamlit secrets."""
-    value = os.getenv(name)
-    if value is not None:
-        return value
-    try:
-        return st.secrets.get(name, default)
-    except Exception:
-        return default
-
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 client = get_openai_client()
 
 if client is None:

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -13,7 +13,6 @@
 
 import streamlit as st
 import hashlib
-import requests
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
@@ -24,12 +23,8 @@ from streamlit_app.cache_utils import (
     limpiar_cache,
 )
 from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
-from streamlit_app.utils.auth_utils import (
-    ensure_session,
-    logout_and_redirect,
-    get_backend_url,
-    handle_401_and_redirect,
-)
+from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect
+from streamlit_app.utils.http_client import api_get
 from streamlit_app.utils.cookies_utils import init_cookie_manager_mount
 
 init_cookie_manager_mount()
@@ -37,7 +32,6 @@ init_cookie_manager_mount()
 # ── Config ───────────────────────────────────────────
 load_dotenv()
 
-BACKEND_URL = get_backend_url()
 st.set_page_config(page_title="Mis Nichos", page_icon="📁")
 
 
@@ -166,14 +160,7 @@ for n in nichos_visibles:
 
         # ── Descargar CSV ───────────────────────────
         try:
-            resp = requests.get(
-                f"{BACKEND_URL}/exportar_leads_nicho",
-                headers={"Authorization": f"Bearer {st.session_state.token}"},
-                params={"nicho": n["nicho"]},
-                timeout=60,
-            )
-            if resp.status_code == 401:
-                handle_401_and_redirect()
+            resp = api_get("/exportar_leads_nicho", params={"nicho": n["nicho"]})
             if resp.status_code == 200:
                 cols[0].download_button(
                     "📥 Descargar CSV",

--- a/streamlit_app/pages/4_Tareas.py
+++ b/streamlit_app/pages/4_Tareas.py
@@ -1,4 +1,3 @@
-import os
 import streamlit as st
 from hashlib import md5
 from urllib.parse import urlparse
@@ -10,25 +9,10 @@ from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
 from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
 from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect
 from streamlit_app.utils.cookies_utils import init_cookie_manager_mount
-from streamlit_app.utils import http_client
 
 init_cookie_manager_mount()
 # ────────────────── Config ──────────────────────────
 load_dotenv()
-
-
-def _safe_secret(name: str, default=None):
-    """Safely retrieve configuration from env or Streamlit secrets."""
-    value = os.getenv(name)
-    if value is not None:
-        return value
-    try:
-        return st.secrets.get(name, default)
-    except Exception:
-        return default
-
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
 
@@ -39,8 +23,6 @@ if st.sidebar.button("Cerrar sesión"):
     logout_and_redirect()
 
 plan = (user or {}).get("plan", "free")
-
-HDR = {"Authorization": f"Bearer {st.session_state.token}"}
 ICON = {"general": "🧠", "nicho": "📂", "lead": "🌐"}
 P_ICON = {"alta": "🔴 Alta", "media": "🟡 Media", "baja": "🟢 Baja"}
 HOY = date.today()

--- a/streamlit_app/pages/7_Suscripcion.py
+++ b/streamlit_app/pages/7_Suscripcion.py
@@ -5,8 +5,7 @@ import streamlit as st
 import requests
 from dotenv import load_dotenv
 
-from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect
-from streamlit_app.utils import http_client
+from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect, get_backend_url
 from streamlit_app.plan_utils import force_redirect
 from streamlit_app.utils.cookies_utils import init_cookie_manager_mount
 
@@ -25,8 +24,6 @@ def _safe_secret(name: str, default=None):
     except Exception:
         return default
 
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 st.set_page_config(page_title="💳 Suscripción", page_icon="💳")
 
@@ -70,7 +67,7 @@ with cols[1]:
         if price_basico:
             try:
                 r = requests.post(
-                    f"{BACKEND_URL}/crear_portal_pago",
+                    f"{get_backend_url()}/crear_portal_pago",
                     headers={"Authorization": f"Bearer {st.session_state.token}"},
                     params={"plan": price_basico},
                     timeout=30,
@@ -102,7 +99,7 @@ with cols[2]:
         if price_premium:
             try:
                 r = requests.post(
-                    f"{BACKEND_URL}/crear_portal_pago",
+                    f"{get_backend_url()}/crear_portal_pago",
                     headers={"Authorization": f"Bearer {st.session_state.token}"},
                     params={"plan": price_premium},
                     timeout=30,

--- a/streamlit_app/pages/8_Mi_Cuenta.py
+++ b/streamlit_app/pages/8_Mi_Cuenta.py
@@ -9,8 +9,7 @@ from dotenv import load_dotenv
 from json import JSONDecodeError
 
 from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
-from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect
-from streamlit_app.utils import http_client
+from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect, get_backend_url
 from streamlit_app.plan_utils import subscription_cta, force_redirect
 from streamlit_app.utils.cookies_utils import init_cookie_manager_mount
 
@@ -19,18 +18,6 @@ init_cookie_manager_mount()
 load_dotenv()
 
 
-def _safe_secret(name: str, default=None):
-    """Safely retrieve configuration from env or Streamlit secrets."""
-    value = os.getenv(name)
-    if value is not None:
-        return value
-    try:
-        return st.secrets.get(name, default)
-    except Exception:
-        return default
-
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 st.set_page_config(page_title="Mi Cuenta", page_icon="⚙️")
 
 
@@ -92,7 +79,7 @@ st.subheader("📊 Estadísticas de uso")
 
 resp_nichos = cached_get("mis_nichos", st.session_state.token)
 nichos = resp_nichos.get("nichos", []) if resp_nichos else []
-leads_resp = requests.get(f"{BACKEND_URL}/exportar_todos_mis_leads", headers=headers)
+leads_resp = requests.get(f"{get_backend_url()}/exportar_todos_mis_leads", headers=headers)
 total_leads = 0
 if leads_resp.status_code == 200:
     df = pd.read_csv(io.BytesIO(leads_resp.content))
@@ -153,7 +140,7 @@ with col1:
             price_id = planes[plan_elegido]
             try:
                 r = requests.post(
-                    f"{BACKEND_URL}/crear_portal_pago",
+                    f"{get_backend_url()}/crear_portal_pago",
                     headers=headers,
                     params={"plan": price_id},
                     timeout=30,
@@ -179,12 +166,12 @@ with st.expander("Debug sesión/DB"):
     st.write("Token (prefijo):", (st.session_state.get("token") or "")[:12])
     st.write("Usuario:", st.session_state.get("user"))
     try:
-        dbg_db = requests.get(f"{BACKEND_URL}/debug-db").json()
+        dbg_db = requests.get(f"{get_backend_url()}/debug-db").json()
     except Exception:
         dbg_db = {}
     try:
         dbg_snapshot = requests.get(
-            f"{BACKEND_URL}/debug-user-snapshot", headers=headers
+            f"{get_backend_url()}/debug-user-snapshot", headers=headers
         ).json()
     except Exception:
         dbg_snapshot = {}
@@ -201,7 +188,7 @@ with col2:
         if st.button("🧾 Gestionar suscripción"):
             try:
                 r = requests.post(
-                    f"{BACKEND_URL}/crear_portal_cliente",
+                    f"{get_backend_url()}/crear_portal_cliente",
                     headers=headers,
                     timeout=30,
                 )

--- a/streamlit_app/utils/auth_utils.py
+++ b/streamlit_app/utils/auth_utils.py
@@ -3,8 +3,21 @@ import streamlit as st
 
 
 def get_backend_url() -> str:
-    url = os.getenv("BACKEND_URL", st.secrets.get("BACKEND_URL", "http://localhost:8000"))
-    return url.rstrip("/")
+    # 1) ENV primero
+    env = os.getenv("BACKEND_URL")
+    if env:
+        return env.rstrip("/")
+
+    # 2) st.secrets si existe, sin romper si no hay secrets.toml
+    try:
+        val = st.secrets.get("BACKEND_URL", None)
+        if val:
+            return str(val).rstrip("/")
+    except Exception:
+        pass
+
+    # 3) Fallback
+    return "http://localhost:8000"
 
 
 def ensure_session(require_auth: bool = False):

--- a/streamlit_app/utils/http_client.py
+++ b/streamlit_app/utils/http_client.py
@@ -1,7 +1,8 @@
 import requests
 import streamlit as st
-
 from .auth_utils import get_backend_url, handle_401_and_redirect
+
+BACKEND_URL = get_backend_url()
 
 
 def _session_with_auth():
@@ -13,29 +14,28 @@ def _session_with_auth():
     return s
 
 
-def _url(path: str) -> str:
-    return f"{get_backend_url()}/{path.lstrip('/')}"
-
-
 def api_get(path: str, **kwargs) -> requests.Response:
+    url = f"{BACKEND_URL}/{path.lstrip('/')}"
     with _session_with_auth() as s:
-        resp = s.get(_url(path), timeout=30, **kwargs)
+        resp = s.get(url, timeout=30, **kwargs)
     if resp.status_code == 401:
         handle_401_and_redirect()
     return resp
 
 
 def api_post(path: str, json=None, data=None, params=None, **kwargs) -> requests.Response:
+    url = f"{BACKEND_URL}/{path.lstrip('/')}"
     with _session_with_auth() as s:
-        resp = s.post(_url(path), json=json, data=data, params=params, timeout=30, **kwargs)
+        resp = s.post(url, json=json, data=data, params=params, timeout=30, **kwargs)
     if resp.status_code == 401:
         handle_401_and_redirect()
     return resp
 
 
 def api_delete(path: str, params=None, **kwargs) -> requests.Response:
+    url = f"{BACKEND_URL}/{path.lstrip('/')}"
     with _session_with_auth() as s:
-        resp = s.delete(_url(path), params=params, timeout=30, **kwargs)
+        resp = s.delete(url, params=params, timeout=30, **kwargs)
     if resp.status_code == 401:
         handle_401_and_redirect()
     return resp
@@ -59,4 +59,3 @@ def health_ok() -> bool:
         return r.status_code < 500
     except Exception:
         return False
-

--- a/streamlit_app/utils/http_client.py
+++ b/streamlit_app/utils/http_client.py
@@ -3,8 +3,6 @@ import streamlit as st
 
 from .auth_utils import get_backend_url, handle_401_and_redirect
 
-BACKEND_URL = get_backend_url()
-
 
 def _session_with_auth():
     s = requests.Session()
@@ -15,25 +13,32 @@ def _session_with_auth():
     return s
 
 
-def _request(method: str, path: str, **kwargs) -> requests.Response:
-    url = f"{BACKEND_URL}/{path.lstrip('/')}"
+def _url(path: str) -> str:
+    return f"{get_backend_url()}/{path.lstrip('/')}"
+
+
+def api_get(path: str, **kwargs) -> requests.Response:
     with _session_with_auth() as s:
-        resp = s.request(method, url, timeout=30, **kwargs)
+        resp = s.get(_url(path), timeout=30, **kwargs)
     if resp.status_code == 401:
         handle_401_and_redirect()
     return resp
 
 
-def api_get(path: str, **kwargs) -> requests.Response:
-    return _request("GET", path, **kwargs)
-
-
 def api_post(path: str, json=None, data=None, params=None, **kwargs) -> requests.Response:
-    return _request("POST", path, json=json, data=data, params=params, **kwargs)
+    with _session_with_auth() as s:
+        resp = s.post(_url(path), json=json, data=data, params=params, timeout=30, **kwargs)
+    if resp.status_code == 401:
+        handle_401_and_redirect()
+    return resp
 
 
 def api_delete(path: str, params=None, **kwargs) -> requests.Response:
-    return _request("DELETE", path, params=params, **kwargs)
+    with _session_with_auth() as s:
+        resp = s.delete(_url(path), params=params, timeout=30, **kwargs)
+    if resp.status_code == 401:
+        handle_401_and_redirect()
+    return resp
 
 
 # Backwards compatibility

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,13 @@
 import os
 
 # Provide default environment variables for tests
-os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("ENV", "test")
 os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("ALLOW_ANON_USER", "1")
+
+from backend.database import Base, engine
+from backend import models  # register models
+
+# Ensure tables exist for tests using global TestClient instances
+Base.metadata.create_all(bind=engine)

--- a/tests/test_user_data.py
+++ b/tests/test_user_data.py
@@ -1,0 +1,85 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+from backend.database import Base, engine, SessionLocal
+from backend.models import Usuario, Nicho, LeadExtraido, LeadTarea
+from backend.auth import hashear_password
+
+
+@pytest.fixture()
+def client():
+    Base.metadata.create_all(bind=engine)
+    with TestClient(app) as c:
+        yield c
+    Base.metadata.drop_all(bind=engine)
+
+
+def _seed_data():
+    with SessionLocal() as db:
+        user = Usuario(email="test@example.com", hashed_password=hashear_password("pw"))
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        nicho = Nicho(
+            user_email_lower=user.email_lower,
+            nicho="marketing",
+            nicho_original="Marketing",
+        )
+        lead1 = LeadExtraido(
+            user_email=user.email_lower,
+            user_email_lower=user.email_lower,
+            url="https://a.com",
+            nicho="marketing",
+            nicho_original="Marketing",
+        )
+        lead2 = LeadExtraido(
+            user_email=user.email_lower,
+            user_email_lower=user.email_lower,
+            url="https://b.com",
+            nicho="marketing",
+            nicho_original="Marketing",
+        )
+        tarea = LeadTarea(
+            email=user.email_lower,
+            user_email_lower=user.email_lower,
+            texto="demo",
+            tipo="general",
+        )
+        db.add_all([nicho, lead1, lead2, tarea])
+        db.commit()
+
+
+@pytest.fixture()
+def token(client):
+    _seed_data()
+    resp = client.post(
+        "/login", data={"username": "test@example.com", "password": "pw"}
+    )
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+def test_mis_nichos(client, token):
+    resp = client.get("/mis_nichos", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["nichos"][0]["total_leads"] == 2
+
+
+def test_tareas_pendientes(client, token):
+    resp = client.get(
+        "/tareas_pendientes", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["tareas"]) >= 1
+
+
+def test_debug_user_snapshot(client, token):
+    resp = client.get(
+        "/debug-user-snapshot", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["counts"]["leads"] == 2
+    assert data["plan"] == "free"

--- a/tests/test_user_data.py
+++ b/tests/test_user_data.py
@@ -60,6 +60,17 @@ def token(client):
     return resp.json()["access_token"]
 
 
+def test_login_creates_user_with_free_plan(client):
+    resp = client.post(
+        "/login", data={"username": "nuevo@example.com", "password": "pw"}
+    )
+    assert resp.status_code == 200
+    with SessionLocal() as db:
+        user = db.query(Usuario).filter_by(email_lower="nuevo@example.com").first()
+        assert user is not None
+        assert user.plan == "free"
+
+
 def test_mis_nichos(client, token):
     resp = client.get("/mis_nichos", headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200
@@ -83,3 +94,4 @@ def test_debug_user_snapshot(client, token):
     data = resp.json()
     assert data["counts"]["leads"] == 2
     assert data["plan"] == "free"
+    assert data["db_backend"]


### PR DESCRIPTION
## Summary
- centralize backend URL and session helpers
- add HTTP client with automatic Authorization header and 401 handling
- wire Mis Nichos and Tareas pages through new client

## Testing
- `pytest` *(fails: assert 401 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f3c135dc8323a543b187d1daff45