### PR TITLE
Centralize backend URL and auth handling for Streamlit frontend

### DIFF
--- a/scripts/sql/20250827_add_lead_tarea_auto.sql
+++ b/scripts/sql/20250827_add_lead_tarea_auto.sql
@@ -1,0 +1,2 @@
+ALTER TABLE lead_tarea
+ADD COLUMN IF NOT EXISTS auto boolean DEFAULT false;

--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -1,3 +1,4 @@
+import os
 import streamlit as st
 from requests import ReadTimeout, ConnectTimeout
 from requests.exceptions import ConnectionError
@@ -21,6 +22,13 @@ from streamlit_app.common_paths import APP_DIR, PAGES_DIR
 init_cookie_manager_mount()
 
 st.set_page_config(page_title="OpenSells", page_icon="🧩", layout="wide")
+
+# Inyectar token existente en el cliente HTTP al cargar la página
+if "token" in st.session_state and st.session_state["token"]:
+    http_client.set_auth_token(st.session_state["token"])
+
+if os.getenv("WRAPPER_DEV_MODE", "false").lower() == "true":
+    st.caption(f"🛠️ Dev: usando BACKEND_URL = {http_client.BACKEND_URL}")
 
 
 user, token = ensure_session()
@@ -93,6 +101,7 @@ if not user:
                 set_auth_token(token)
             except Exception:
                 st.warning("No se pudieron guardar las cookies de sesión")
+            http_client.set_auth_token(token)
             ensure_session()
             st.success("¡Sesión iniciada!")
             try:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -14,10 +14,18 @@ import streamlit as st
 
 from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect, require_auth_or_prompt
 from streamlit_app.utils.cookies_utils import init_cookie_manager_mount
+from streamlit_app.utils import http_client
 
 init_cookie_manager_mount()
 
 st.set_page_config(page_title="OpenSells — tu motor de prospección y leads", page_icon="🧩")
+
+# Inyectar token existente y mostrar badge en modo desarrollo
+if "token" in st.session_state and st.session_state["token"]:
+    http_client.set_auth_token(st.session_state["token"])
+
+if os.getenv("WRAPPER_DEV_MODE", "false").lower() == "true":
+    st.caption(f"🛠️ Dev: usando BACKEND_URL = {http_client.BACKEND_URL}")
 
 
 if not require_auth_or_prompt():

--- a/streamlit_app/cache_utils.py
+++ b/streamlit_app/cache_utils.py
@@ -1,25 +1,11 @@
 import os
 import streamlit as st
-import requests
 from dotenv import load_dotenv
 from openai import OpenAI
-from urllib.parse import urlencode
+from streamlit_app.utils import http_client
 
 load_dotenv()
 
-
-def _safe_secret(name: str, default=None):
-    """Safely retrieve configuration from env or Streamlit secrets."""
-    value = os.getenv(name)
-    if value is not None:
-        return value
-    try:
-        return st.secrets.get(name, default)
-    except Exception:
-        return default
-
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 @st.cache_resource
 def get_openai_client() -> OpenAI | None:
@@ -28,34 +14,21 @@ def get_openai_client() -> OpenAI | None:
     return OpenAI(api_key=key) if key else None
 
 @st.cache_data
-def auth_headers(token: str) -> dict:
-    """Authorization headers for a given token."""
-    return {"Authorization": f"Bearer {token}"}
-
-@st.cache_data
 def cached_get(endpoint, token, query=None, nocache_key=None):
-    """
-    GET con caché de Streamlit. Si nocache_key cambia, se fuerza recarga.
-    """
-    url = f"{BACKEND_URL}/{endpoint}"
-    headers = {"Authorization": f"Bearer {token}"}
-    if query:
-        url += "?" + urlencode(query)
+    """GET con caché de Streamlit. Si nocache_key cambia, se fuerza recarga."""
     try:
-        response = requests.get(url, headers=headers)
-        if response.status_code == 200:
-            return response.json()
+        resp = http_client.get(f"/{endpoint}", params=query)
+        if resp is not None and resp.status_code == 200:
+            return resp.json()
     except Exception as e:
         print(f"[cached_get] Error: {e}")
     return {}
 
 
 def cached_delete(endpoint, token, params=None):
-    url = f"{BACKEND_URL}/{endpoint}"
-    headers = {"Authorization": f"Bearer {token}"}
     try:
-        r = requests.delete(url, headers=headers, params=params)
-        if r.status_code == 200:
+        r = http_client.delete(f"/{endpoint}", params=params)
+        if r is not None and r.status_code == 200:
             return r.json()
         return None
     except Exception as e:
@@ -64,16 +37,18 @@ def cached_delete(endpoint, token, params=None):
 
 
 def cached_post(endpoint, token, payload=None, params=None):
-    url = f"{BACKEND_URL}/{endpoint}"
-    headers = {"Authorization": f"Bearer {token}"}
     try:
-        r = requests.post(url, headers=headers, json=payload, params=params)
-        if r.status_code == 200:
+        r = http_client.post(f"/{endpoint}", json=payload, params=params)
+        if r is not None and r.status_code == 200:
             # Limpiar cache relevante si es una acción conocida
             if endpoint in ["tarea_completada", "editar_tarea", "tarea_lead"]:
                 if "_cache" in st.session_state:
                     for key in list(st.session_state._cache.keys()):
-                        if "tareas_pendientes" in key or "tareas_lead" in key or "tareas_nicho" in key:
+                        if (
+                            "tareas_pendientes" in key
+                            or "tareas_lead" in key
+                            or "tareas_nicho" in key
+                        ):
                             del st.session_state._cache[key]
             return r.json()
     except Exception as e:

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -195,6 +195,12 @@ for n in nichos_visibles:
     ):
         cols = st.columns([1, 1])
 
+        estado_filtro = st.selectbox(
+            "Estado de contacto",
+            ["todos", "no_contactado", "en_proceso", "contactado"],
+            key=f"estado_filtro_{n['nicho']}",
+        )
+
         # ── Descargar CSV ───────────────────────────
         try:
             params_export = {"nicho": n["nicho"]}
@@ -231,12 +237,6 @@ for n in nichos_visibles:
                     st.rerun()
                 else:
                     st.error("Error al eliminar el nicho")
-
-        estado_filtro = st.selectbox(
-            "Estado de contacto",
-            ["todos", "no_contactado", "en_proceso", "contactado"],
-            key=f"estado_filtro_{n['nicho']}",
-        )
         query_params = {"nicho": n["nicho"]}
         if estado_filtro != "todos":
             query_params["estado_contacto"] = estado_filtro

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -11,10 +11,8 @@
 #      reruns innecesarios.
 #   4. Limpieza y tipado ligero.
 
-import os
 import streamlit as st
 import hashlib
-import requests
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 
@@ -34,19 +32,8 @@ init_cookie_manager_mount()
 # ── Config ───────────────────────────────────────────
 load_dotenv()
 
-
-def _safe_secret(name: str, default=None):
-    """Safely retrieve configuration from env or Streamlit secrets."""
-    value = os.getenv(name)
-    if value is not None:
-        return value
-    try:
-        return st.secrets.get(name, default)
-    except Exception:
-        return default
-
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
+if "token" in st.session_state and st.session_state["token"]:
+    http_client.set_auth_token(st.session_state["token"])
 st.set_page_config(page_title="Mis Nichos", page_icon="📁")
 
 st.markdown(
@@ -213,9 +200,8 @@ for n in nichos_visibles:
             params_export = {"nicho": n["nicho"]}
             if estado_filtro != "todos":
                 params_export["estado_contacto"] = estado_filtro
-            resp = requests.get(
-                f"{BACKEND_URL}/exportar_leads_nicho",
-                headers={"Authorization": f"Bearer {st.session_state.token}"},
+            resp = http_client.get(
+                "/exportar_leads_nicho",
                 params=params_export,
             )
             if resp.status_code == 200:

--- a/streamlit_app/pages/4_Tareas.py
+++ b/streamlit_app/pages/4_Tareas.py
@@ -51,6 +51,19 @@ elif "nicho" in params:
 if "tarea_seccion_activa" not in st.session_state:
     st.session_state["tarea_seccion_activa"] = "⏳ Pendientes"
 
+# ────────────────── Layout ──────────────────────────
+st.title("📋 Tareas")
+titles = ["⏳ Pendientes", "🧠 General", "📂 Nichos", "🌐 Leads"]
+
+seccion = st.radio(
+    "Secciones",
+    titles,
+    key="tarea_seccion_activa",
+    index=titles.index(st.session_state["tarea_seccion_activa"]),
+    label_visibility="collapsed",
+    horizontal=True,
+)
+
 # ────────────────── Helpers ─────────────────────────
 def _hash(v):
     return md5(str(v).encode()).hexdigest()
@@ -65,7 +78,8 @@ def norm_dom(url: str) -> str:
 
 # ────────────────── Datos base ──────────────────────
 datos_tareas = cached_get("tareas_pendientes", st.session_state.token, nocache_key=time.time())
-todos = [t for t in (datos_tareas.get("tareas") if datos_tareas else []) if not t.get("completado", False)]
+datos_tareas = datos_tareas or {"tareas": []}
+todos = [t for t in datos_tareas.get("tareas", []) if not t.get("completado", False)]
 datos_nichos = cached_get("mis_nichos", st.session_state.token)
 map_n = {n["nicho"]: n["nicho_original"] for n in (datos_nichos.get("nichos") if datos_nichos else [])}
 
@@ -170,20 +184,6 @@ def render_list(items: list[dict], key_pref: str):
             if c5.button("❌", key=f"cerrar_edit_{unique_key}"):
                 st.session_state[f"editando_{unique_key}"] = False
                 st.rerun()
-
-# ────────────────── Layout ──────────────────────────
-
-st.title("📋 Tareas")
-titles = ["⏳ Pendientes", "🧠 General", "📂 Nichos", "🌐 Leads"]
-
-seccion = st.radio(
-    "Secciones",
-    titles,
-    key="tarea_seccion_activa",
-    index=titles.index(st.session_state["tarea_seccion_activa"]),
-    label_visibility="collapsed",
-    horizontal=True,
-)
 
 if seccion == titles[0]:
     st.subheader("⏳ Todas las pendientes")

--- a/streamlit_app/pages/4_Tareas.py
+++ b/streamlit_app/pages/4_Tareas.py
@@ -1,4 +1,3 @@
-import os
 import streamlit as st
 from hashlib import md5
 from urllib.parse import urlparse
@@ -16,19 +15,8 @@ init_cookie_manager_mount()
 # ────────────────── Config ──────────────────────────
 load_dotenv()
 
-
-def _safe_secret(name: str, default=None):
-    """Safely retrieve configuration from env or Streamlit secrets."""
-    value = os.getenv(name)
-    if value is not None:
-        return value
-    try:
-        return st.secrets.get(name, default)
-    except Exception:
-        return default
-
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
+if "token" in st.session_state and st.session_state["token"]:
+    http_client.set_auth_token(st.session_state["token"])
 
 st.set_page_config(page_title="Tareas", page_icon="📋", layout="centered")
 
@@ -43,8 +31,6 @@ if st.sidebar.button("Cerrar sesión"):
     logout_and_redirect()
 
 plan = (user or {}).get("plan", "free")
-
-HDR = {"Authorization": f"Bearer {st.session_state.token}"}
 ICON = {"general": "🧠", "nicho": "📂", "lead": "🌐"}
 P_ICON = {"alta": "🔴 Alta", "media": "🟡 Media", "baja": "🟢 Baja"}
 HOY = date.today()

--- a/streamlit_app/pages/7_Suscripcion.py
+++ b/streamlit_app/pages/7_Suscripcion.py
@@ -2,7 +2,6 @@
 
 import os
 import streamlit as st
-import requests
 from dotenv import load_dotenv
 
 from streamlit_app.utils.auth_utils import ensure_session, logout_and_redirect, require_auth_or_prompt
@@ -15,6 +14,9 @@ init_cookie_manager_mount()
 
 load_dotenv()
 
+if "token" in st.session_state and st.session_state["token"]:
+    http_client.set_auth_token(st.session_state["token"])
+
 
 def _safe_secret(name: str, default=None):
     """Safely retrieve configuration from env or Streamlit secrets."""
@@ -26,8 +28,6 @@ def _safe_secret(name: str, default=None):
     except Exception:
         return default
 
-
-BACKEND_URL = _safe_secret("BACKEND_URL", "https://opensells.onrender.com")
 
 st.set_page_config(page_title="💳 Suscripción", page_icon="💳")
 
@@ -81,9 +81,8 @@ for idx, (nombre, feats) in enumerate(plan_features.items()):
             if st.button("Suscribirme al Pro"):
                 if price_basico:
                     try:
-                        r = requests.post(
-                            f"{BACKEND_URL}/crear_portal_pago",
-                            headers={"Authorization": f"Bearer {st.session_state.token}"},
+                        r = http_client.post(
+                            "/crear_portal_pago",
                             params={"plan": price_basico},
                             timeout=30,
                         )
@@ -104,9 +103,8 @@ for idx, (nombre, feats) in enumerate(plan_features.items()):
             if st.button("Suscribirme al Business"):
                 if price_premium:
                     try:
-                        r = requests.post(
-                            f"{BACKEND_URL}/crear_portal_pago",
-                            headers={"Authorization": f"Bearer {st.session_state.token}"},
+                        r = http_client.post(
+                            "/crear_portal_pago",
                             params={"plan": price_premium},
                             timeout=30,
                         )

--- a/streamlit_app/utils/auth_utils.py
+++ b/streamlit_app/utils/auth_utils.py
@@ -7,6 +7,10 @@ from streamlit_app.utils.cookies_utils import (
     clear_auth_token,
 )
 
+# Inyecta el token existente al cliente HTTP al cargar el módulo
+if "token" in st.session_state and st.session_state["token"]:
+    http_client.set_auth_token(st.session_state["token"])
+
 
 def require_auth_or_prompt() -> bool:
     """Check for a session token and prompt login when absent."""
@@ -24,6 +28,7 @@ def clear_session():
         clear_auth_token()
     except Exception:
         pass
+    http_client.set_auth_token(None)
 
 
 def ensure_session() -> Tuple[Optional[dict], Optional[str]]:
@@ -33,7 +38,8 @@ def ensure_session() -> Tuple[Optional[dict], Optional[str]]:
         return None, None
 
     st.session_state["token"] = token
-    resp = http_client.get("/me", headers={"Authorization": f"Bearer {token}"})
+    http_client.set_auth_token(token)
+    resp = http_client.get("/me")
     if getattr(resp, "status_code", None) == 200:
         user = resp.json()
         st.session_state["user"] = user

--- a/streamlit_app/utils/http_client.py
+++ b/streamlit_app/utils/http_client.py
@@ -6,7 +6,8 @@ from urllib3.util.retry import Retry
 import streamlit as st
 from streamlit_app.utils.auth_utils import clear_session
 
-BACKEND_URL = os.getenv("BACKEND_URL", "https://opensells.onrender.com").rstrip("/")
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000").rstrip("/")
+DEV = os.getenv("WRAPPER_DEV_MODE", "false").lower() == "true"
 
 _session = requests.Session()
 _retries = Retry(
@@ -21,10 +22,21 @@ _session.mount("http://", _adapter)
 _session.mount("https://", _adapter)
 
 _extra_headers: dict[str, str] = {}
+_auth_token: str | None = None
+_logged_backend_once = False
 
 # timeouts: (connect_timeout, read_timeout)
 DEFAULT_TIMEOUT = (5, 60)  # conectar rápido; dar margen al backend "cold start"
 LONG_TIMEOUT = (5, 120)    # para /login si Render está frío
+
+
+def _log_backend_once():
+    """Muestra BACKEND_URL una sola vez en modo dev."""
+    global _logged_backend_once
+    if DEV and not _logged_backend_once:
+        print(f"[DEV] BACKEND_URL: {BACKEND_URL}")
+        _logged_backend_once = True
+
 
 def _url(path: str) -> str:
     return urljoin(BACKEND_URL + "/", path.lstrip("/"))
@@ -36,11 +48,23 @@ def set_extra_headers(headers: dict[str, str] | None):
     _extra_headers = headers or {}
 
 
-def _merge_headers(headers: dict | None) -> dict:
-    combined = dict(_extra_headers)
+def set_auth_token(token: str | None):
+    """Guarda el token a usar en futuras peticiones."""
+    global _auth_token
+    _auth_token = token
+
+
+def _headers(path: str, headers: dict | None = None) -> dict:
+    h = {"Accept": "application/json"}
+    h.update(_extra_headers)
     if headers:
-        combined.update(headers)
-    return combined
+        h.update(headers)
+    if _auth_token:
+        h["Authorization"] = f"Bearer {_auth_token}"
+    elif DEV and not path.endswith("/login"):
+        print(f"[DEV][WARN] Request a {path} sin Authorization (token vacío).")
+    return h
+
 
 def _handle_401(resp):
     if resp is not None and getattr(resp, "status_code", None) == 401:
@@ -55,23 +79,28 @@ def _handle_401(resp):
 
 
 def get(path: str, **kwargs):
+    _log_backend_once()
     timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT)
-    headers = _merge_headers(kwargs.pop("headers", None))
-    resp = _session.get(_url(path), headers=headers, timeout=timeout, **kwargs)
+    headers = kwargs.pop("headers", None)
+    resp = _session.get(_url(path), headers=_headers(path, headers), timeout=timeout, **kwargs)
     return _handle_401(resp)
 
+
 def post(path: str, **kwargs):
+    _log_backend_once()
     timeout = kwargs.pop("timeout", LONG_TIMEOUT)
-    headers = _merge_headers(kwargs.pop("headers", None))
-    resp = _session.post(_url(path), headers=headers, timeout=timeout, **kwargs)
+    headers = kwargs.pop("headers", None)
+    resp = _session.post(_url(path), headers=_headers(path, headers), timeout=timeout, **kwargs)
     return _handle_401(resp)
 
 
 def delete(path: str, **kwargs):
+    _log_backend_once()
     timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT)
-    headers = _merge_headers(kwargs.pop("headers", None))
-    resp = _session.delete(_url(path), headers=headers, timeout=timeout, **kwargs)
+    headers = kwargs.pop("headers", None)
+    resp = _session.delete(_url(path), headers=_headers(path, headers), timeout=timeout, **kwargs)
     return _handle_401(resp)
+
 
 def health_ok() -> bool:
     try:


### PR DESCRIPTION
## Summary
- Add HTTP client wrapper that reads BACKEND_URL, manages auth token and dev logging
- Sync Streamlit session tokens with HTTP client and show dev backend badge when enabled
- Route all backend calls through the shared client and remove hardcoded URLs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af3b8b0a048323b9396f1db23bcd86