### PR TITLE
Ensure lead contact state column exists

### DIFF
--- a/backend/alembic/versions/20240228_add_estado_contacto_to_leads_extraidos.py
+++ b/backend/alembic/versions/20240228_add_estado_contacto_to_leads_extraidos.py
@@ -1,0 +1,26 @@
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '20240228_add_estado_contacto_to_leads_extraidos'
+down_revision = '20250108_unify_tenant_key'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        ALTER TABLE leads_extraidos
+        ADD COLUMN IF NOT EXISTS estado_contacto VARCHAR(20) NOT NULL DEFAULT 'pendiente'
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        ALTER TABLE leads_extraidos
+        DROP COLUMN IF EXISTS estado_contacto
+        """
+    )

--- a/backend/main.py
+++ b/backend/main.py
@@ -95,6 +95,7 @@ from backend.db import guardar_estado_lead, obtener_estado_lead
 from sqlalchemy.orm import Session
 from backend.db import obtener_nichos_para_url
 from backend.webhook import router as webhook_router
+from backend.startup_migrations import ensure_estado_contacto_column
 
 load_dotenv()
 
@@ -118,6 +119,7 @@ async def startup():
     logger.warning("SQLAlchemy engine: %s", engine.url)
     Base.metadata.create_all(bind=engine)
     crear_tablas_si_no_existen()  # ✅ función síncrona, se llama normal
+    ensure_estado_contacto_column(engine)
 
 def normalizar_nicho(texto: str) -> str:
     texto = texto.strip().lower()

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,7 +5,7 @@ import enum
 
 
 class LeadEstadoContacto(enum.Enum):
-    no_contactado = "no_contactado"
+    pendiente = "pendiente"
     en_proceso = "en_proceso"
     contactado = "contactado"
 
@@ -101,7 +101,7 @@ class LeadExtraido(Base):
     timestamp = Column(DateTime(timezone=True), server_default=func.now())
     nicho = Column(String, nullable=False)  # Normalizado
     nicho_original = Column(String, nullable=False)
-    estado_contacto = Column(String, nullable=False, server_default="no_contactado", index=True)
+    estado_contacto = Column(String(20), nullable=False, server_default="pendiente", index=True)
 
     @validates("user_email")
     def _set_lower(self, key, value):

--- a/backend/startup_migrations.py
+++ b/backend/startup_migrations.py
@@ -1,0 +1,23 @@
+import logging
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_estado_contacto_column(engine: Engine) -> None:
+    """Ensure leads_extraidos.estado_contacto exists with safe default."""
+    insp = inspect(engine)
+    columns = [col["name"] for col in insp.get_columns("leads_extraidos")]
+    if "estado_contacto" in columns:
+        return
+
+    logger.warning("Columna estado_contacto ausente; creando en leads_extraidos")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "ALTER TABLE leads_extraidos "
+                "ADD COLUMN estado_contacto VARCHAR(20) NOT NULL DEFAULT 'pendiente'"
+            )
+        )
+    logger.info("Columna estado_contacto creada")

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -93,8 +93,8 @@ def md5(s: str) -> str:
 
 
 def render_estado_badge(estado: str) -> str:
-    if estado == "no_contactado":
-        return '<span class="badge badge-warn">No contactado</span>'
+    if estado == "pendiente":
+        return '<span class="badge badge-warn">Pendiente</span>'
     if estado == "en_proceso":
         return '<span class="badge badge-info">En proceso</span>'
     return '<span class="badge badge-ok">Contactado</span>'
@@ -248,7 +248,7 @@ for n in nichos_visibles:
 
         estado_filtro = st.selectbox(
             "Estado de contacto",
-            ["todos", "no_contactado", "en_proceso", "contactado"],
+            ["todos", "pendiente", "en_proceso", "contactado"],
             key=f"estado_filtro_{n['nicho']}",
         )
         query_params = {"nicho": n["nicho"]}
@@ -342,7 +342,7 @@ for n in nichos_visibles:
 
         for i, l in enumerate(leads):
             dominio = normalizar_dominio(l["url"])
-            estado_actual = l.get("estado_contacto", "no_contactado")
+            estado_actual = l.get("estado_contacto", "pendiente")
             clave_base = f"{dominio}_{n['nicho']}_{i}".replace(".", "_")
             cols_row = st.columns([3, 2, 1, 1, 1])
             cols_row[0].markdown(
@@ -353,8 +353,8 @@ for n in nichos_visibles:
             sel_key = f"estado_sel_{clave_base}"
             cols_row[1].selectbox(
                 "",
-                ["no_contactado", "en_proceso", "contactado"],
-                index=["no_contactado", "en_proceso", "contactado"].index(estado_actual),
+                ["pendiente", "en_proceso", "contactado"],
+                index=["pendiente", "en_proceso", "contactado"].index(estado_actual),
                 key=sel_key,
                 on_change=_cambiar_estado,
                 args=(sel_key, dominio),

--- a/tests/test_estado_contacto_defaults.py
+++ b/tests/test_estado_contacto_defaults.py
@@ -1,0 +1,24 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.models import Base, LeadExtraido
+
+
+def test_estado_contacto_default():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    lead = LeadExtraido(
+        user_email="a",
+        user_email_lower="a",
+        url="b",
+        nicho="n",
+        nicho_original="n",
+    )
+    session.add(lead)
+    session.commit()
+
+    fetched = session.query(LeadExtraido).first()
+    assert fetched.estado_contacto == "pendiente"

--- a/tests/test_lead_contact_task.py
+++ b/tests/test_lead_contact_task.py
@@ -21,7 +21,7 @@ def test_guardar_lead_crea_estado_y_tarea():
 
     lead = session.query(LeadExtraido).first()
     assert lead is not None
-    assert lead.estado_contacto == "no_contactado"
+    assert lead.estado_contacto == "pendiente"
 
     tarea = session.query(LeadTarea).first()
     assert tarea is not None

--- a/tests/test_listado_nichos_no_revienta.py
+++ b/tests/test_listado_nichos_no_revienta.py
@@ -1,0 +1,29 @@
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from backend.db import obtener_leads_por_nicho
+
+
+def test_listado_nichos_no_revienta():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE leads_extraidos (
+                    id INTEGER PRIMARY KEY,
+                    user_email TEXT NOT NULL,
+                    user_email_lower TEXT NOT NULL,
+                    url TEXT NOT NULL,
+                    timestamp TEXT,
+                    nicho TEXT NOT NULL,
+                    nicho_original TEXT NOT NULL
+                )
+                """
+            )
+        )
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    datos = obtener_leads_por_nicho("a", "n", session)
+    assert datos == []

--- a/tests/test_migracion_estado_contacto.py
+++ b/tests/test_migracion_estado_contacto.py
@@ -1,0 +1,38 @@
+from sqlalchemy import create_engine, text, inspect
+
+from backend.startup_migrations import ensure_estado_contacto_column
+
+
+def test_migracion_estado_contacto():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE leads_extraidos (
+                    id INTEGER PRIMARY KEY,
+                    user_email TEXT NOT NULL,
+                    user_email_lower TEXT NOT NULL,
+                    url TEXT NOT NULL,
+                    timestamp TEXT,
+                    nicho TEXT NOT NULL,
+                    nicho_original TEXT NOT NULL
+                )
+                """
+            )
+        )
+
+    ensure_estado_contacto_column(engine)
+
+    insp = inspect(engine)
+    cols = [c["name"] for c in insp.get_columns("leads_extraidos")]
+    assert "estado_contacto" in cols
+
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO leads_extraidos (user_email, user_email_lower, url, nicho, nicho_original) VALUES ('a','a','b','n','n')"
+            )
+        )
+        val = conn.execute(text("SELECT estado_contacto FROM leads_extraidos")).scalar_one()
+    assert val == "pendiente"


### PR DESCRIPTION
## Summary
- add Alembic migration to add `estado_contacto` with default `pendiente`
- create startup helper to auto-add missing column and call on app start
- update lead model, DB utilities, and Streamlit UI to use new default
- cover migration and defaults with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af8e5af65483238872a3f80beb3dbf