### PR TITLE
feat(home): actualizar marca a OpenSells y reponer registro con auto-login

### DIFF
--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -6,160 +6,92 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
-from streamlit_app.cache_utils import cached_get
-from streamlit_app.common_paths import PAGES_DIR
+from streamlit_app.utils.constants import BRAND
 from streamlit_app.utils.nav import go
-from streamlit_app.utils.auth_session import (
+from streamlit_app.utils.http_client import post, login as http_login
+from streamlit_app.utils.auth_utils import (
     is_authenticated,
-    set_auth_token,
-    remember_current_page,
-    clear_auth_token,
-    clear_page_remember,
-    get_auth_token,
-    bootstrap_auth_once,   # 👈 NEW import
+    save_session,
+    restore_session_if_allowed,
 )
-from streamlit_app.utils.http_client import get, login as http_login
 
-st.set_page_config(page_title="OpenSells", page_icon="🧩", layout="wide")
+st.set_page_config(page_title=f"{BRAND} — Accede a tu cuenta", layout="wide")
 
-PAGE_NAME = "Home"
+restore_session_if_allowed()
 
+st.markdown(f"# {BRAND}")
+st.subheader("Accede a tu cuenta")
 
-def render_login():
-    st.title("Wrapper Leads SaaS")
-    st.subheader("Accede a tu cuenta")
-    with st.form("login_form"):
-        username = st.text_input("Usuario o email")
-        password = st.text_input("Contraseña", type="password")
-        submitted = st.form_submit_button("Entrar")
+if is_authenticated():
+    st.info("Ya has iniciado sesión")
+    st.button(
+        "Ir a Búsqueda",
+        use_container_width=True,
+        on_click=lambda: go("pages/1_Busqueda.py"),
+    )
+else:
+    tabs = st.tabs(["Entrar", "Crear cuenta"])
+
+    with tabs[0]:
+        with st.form("login_form"):
+            username = st.text_input("Usuario o email")
+            password = st.text_input("Contraseña", type="password")
+            submitted = st.form_submit_button("Entrar", use_container_width=True)
         if submitted:
             result = http_login(username, password)
             if isinstance(result, dict) and result.get("_error"):
                 st.error("No autorizado. Revisa tus credenciales.")
-                return
-            resp = result.get("response")
-            token = result.get("token")
-            if not token:
-                status = getattr(resp, "status_code", "unknown")
-                body = getattr(resp, "text", "")[:500]
-                st.error("No se recibió token de acceso.")
-                st.info(f"status: {status}\nbody: {body}")
-                return
-            set_auth_token(token)
-            st.rerun()
+            else:
+                resp = result.get("response")
+                token = result.get("token")
+                if not token:
+                    status = getattr(resp, "status_code", "unknown")
+                    body = getattr(resp, "text", "")[:500]
+                    st.error("No se recibió token de acceso.")
+                    st.info(f"status: {status}\nbody: {body}")
+                else:
+                    save_session(token, username)
+                    go("app.py")
 
-
-def render_logout_button():
-    with st.sidebar:
-        if st.button("Cerrar sesión", type="secondary"):
-            clear_auth_token()
-            clear_page_remember()
-            st.rerun()
-
-
-def render_home_private():
-    token = get_auth_token()
-    user = st.session_state.get("user")
-    if token and not user:
-        me = get("/me")
-        if isinstance(me, dict) and me.get("_error") == "unauthorized":
-            st.warning("Sesión expirada. Inicia sesión de nuevo.")
-            clear_auth_token()
-            st.rerun()
-        if getattr(me, "status_code", None) == 200:
-            user = me.json()
-            st.session_state["user"] = user
-
-    st.markdown(
-        """
-    <div style="text-align:center; margin-top: 1rem; margin-bottom: 1rem;">
-        <h1 style="margin-bottom:0.25rem;">✨ Opensells</h1>
-        <p style="font-size:1.1rem; margin-top:0;">IA de generación y gestión de leads para multiplicar x1000 tus ventas.</p>
-    </div>
-    """,
-        unsafe_allow_html=True,
-    )
-
-    def page_exists(name: str) -> bool:
-        return (PAGES_DIR / name).exists()
-
-    PAGES = {
-        "assistant": "2_Asistente_Virtual.py",
-        "busqueda": "1_Busqueda.py",
-        "nichos": "3_Mis_Nichos.py",
-        "tareas": "4_Tareas.py",
-        "export": "5_Exportaciones.py",
-        "emails": "6_Emails.py",
-        "suscripcion": "7_Suscripcion.py",
-        "cuenta": "8_Mi_Cuenta.py",
-    }
-
-    plan = (user or {}).get("plan", "free")
-    suscripcion_activa = tiene_suscripcion_activa(plan)
-
-    nichos = cached_get("mis_nichos", st.session_state.get("auth_token")) or {}
-    num_nichos = len(nichos.get("nichos", []))
-
-    _tareas = cached_get("tareas_pendientes", st.session_state.get("auth_token")) or []
-    num_tareas = len([t for t in _tareas if not t.get("completado")])
-
-    col1, col2 = st.columns(2, gap="large")
-    with col1:
-        st.subheader("🗨️ Modo Asistente Virtual (Beta)")
-        st.markdown(
-            "Interactúa por chat para pedir acciones y consejos. (La búsqueda de leads desde el asistente llegará más adelante)"
-        )
-        st.button(
-            "🗨️ Asistente Virtual",
-            use_container_width=True,
-            disabled=not suscripcion_activa,
-            on_click=lambda: go(f"pages/{PAGES['assistant']}")
-        )
-        if not suscripcion_activa:
-            subscription_cta()
-
-    with col2:
-        st.subheader("📊 Modo Clásico")
-        st.markdown("Genera leads únicos con cada búsqueda.")
-        st.button(
-            "🔎 Búsqueda de Leads",
-            use_container_width=True,
-            on_click=lambda: go(f"pages/{PAGES['busqueda']}")
-        )
-
-    st.divider()
-
-    accesos = st.columns(4)
-    items = [
-        ("📂 Mis Nichos", "nichos"),
-        ("📋 Tareas", "tareas"),
-        ("📤 Exportaciones", "export"),
-        ("⚙️ Mi Cuenta", "cuenta"),
-    ]
-    for col, (label, key) in zip(accesos, items):
-        page_file = PAGES.get(key)
-        if page_file and page_exists(page_file):
-            if col.button(label, use_container_width=True):
-                go(f"pages/{page_file}")
-
-    with st.expander("Resumen de tu actividad"):
-        st.write(f"**Número de nichos:** {num_nichos}")
-        st.write(f"**Número de tareas pendientes:** {num_tareas}")
-        if not suscripcion_activa:
-            subscription_cta()
-
-
-def main():
-    remember_current_page(PAGE_NAME)
-    bootstrap_auth_once()  # 👈 NEW: restore token on first render
-
-    if not is_authenticated():
-        render_login()
-        return
-    render_logout_button()
-    render_home_private()
-
+    with tabs[1]:
+        with st.form("register_form"):
+            name = st.text_input("Nombre (opcional)")
+            email = st.text_input("Email")
+            password_reg = st.text_input("Contraseña", type="password")
+            submitted_reg = st.form_submit_button("Crear cuenta", use_container_width=True)
+        if submitted_reg:
+            payload = {"email": email, "password": password_reg}
+            if name:
+                payload["name"] = name
+            resp = post(
+                "/register",
+                json=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            if isinstance(resp, dict) and resp.get("_error"):
+                st.error("Error de autenticación.")
+            elif getattr(resp, "status_code", 0) >= 400:
+                if resp.status_code in (400, 409):
+                    st.error("Ese email ya está registrado")
+                else:
+                    body = getattr(resp, "text", "")[:500]
+                    st.error(f"Error al crear cuenta: {resp.status_code}. {body}")
+            else:
+                st.success("Cuenta creada. Iniciando sesión...")
+                login_res = http_login(email, password_reg)
+                if isinstance(login_res, dict) and login_res.get("_error"):
+                    st.error("Error al iniciar sesión automáticamente.")
+                else:
+                    resp_login = login_res.get("response")
+                    token = login_res.get("token")
+                    if not token:
+                        status = getattr(resp_login, "status_code", "unknown")
+                        body = getattr(resp_login, "text", "")[:500]
+                        st.error("No se recibió token de acceso.")
+                        st.info(f"status: {status}\nbody: {body}")
+                    else:
+                        save_session(token, email)
+                        go("app.py")
 
 if __name__ == "__main__":
-    main()
+    pass

--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -6,5 +6,6 @@ imported here for convenient access as ``from utils import ...``.
 
 from streamlit_app.utils.style_utils import full_width_button
 from streamlit_app.utils import http_client
+from streamlit_app.utils.constants import BRAND
 
-__all__ = ["full_width_button", "http_client"]
+__all__ = ["full_width_button", "http_client", "BRAND"]

--- a/streamlit_app/utils/constants.py
+++ b/streamlit_app/utils/constants.py
@@ -1,0 +1,5 @@
+import os
+
+BRAND = os.getenv("BRAND_NAME", "OpenSells")
+
+__all__ = ["BRAND"]


### PR DESCRIPTION
## Summary
- add reusable BRAND constant for frontend
- rebuild Home with brand-aware login and registration tabs, including auto-login after sign up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdb461053883238ee5f59a936892e7