### PR TITLE
fix(nav): export HOME_PAGE and robust go()

### DIFF
--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -1,16 +1,12 @@
-"""Utility package for Streamlit frontend.
+"""Utility package for the Streamlit frontend.
 
-Exposes helpers shared across the Streamlit pages.  New utilities should be
-imported here for convenient access as ``from utils import ...``.
+Expose helpers shared across Streamlit pages. New utilities should be imported
+here for convenient access as ``from utils import ...``.
 """
 
-from streamlit_app.utils.style_utils import full_width_button
-from streamlit_app.utils import http_client
-from streamlit_app.utils.constants import (
-    BRAND,
-    AFTER_LOGIN_PAGE_LABEL,
-    AFTER_LOGIN_PAGE_PATH,
-)
+from .style_utils import full_width_button
+from . import http_client
+from .constants import BRAND, AFTER_LOGIN_PAGE_LABEL, AFTER_LOGIN_PAGE_PATH
 
 __all__ = [
     "full_width_button",

--- a/streamlit_app/utils/constants.py
+++ b/streamlit_app/utils/constants.py
@@ -1,13 +1,8 @@
 import os
 
-# existing constant
 BRAND = os.getenv("BRAND_NAME", "OpenSells")
 
-# new navigation constants
 AFTER_LOGIN_PAGE_LABEL = os.getenv("AFTER_LOGIN_PAGE_LABEL", "Buscar leads")
-# Alternative direct path (used if label fails)
-AFTER_LOGIN_PAGE_PATH = os.getenv(
-    "AFTER_LOGIN_PAGE_PATH", "pages/Buscar_leads.py"
-)
+AFTER_LOGIN_PAGE_PATH = os.getenv("AFTER_LOGIN_PAGE_PATH", "pages/Buscar_leads.py")
 
 __all__ = ["BRAND", "AFTER_LOGIN_PAGE_LABEL", "AFTER_LOGIN_PAGE_PATH"]


### PR DESCRIPTION
## Summary
- expose navigation constants AFTER_LOGIN_PAGE_* alongside BRAND
- add retro-compatible HOME_PAGE alias and resilient `go` helper
- use new navigation defaults in Home page and export from utils package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdbc95dfb4832392f48b0fb901aafd