### PR TITLE
feat(home): dashboard post-login con dos CTAs principales y accesos secundarios

### DIFF
--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -6,7 +6,12 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from utils import BRAND
+from utils import (
+    BRAND,
+    LEADS_PAGE_LABEL,
+    ASSISTANT_PAGE_LABEL,
+    SECONDARY_PAGES,
+)
 from utils.nav import go
 from utils.http_client import post, login as http_login
 from utils.auth_utils import (
@@ -14,22 +19,110 @@ from utils.auth_utils import (
     save_session,
     restore_session_if_allowed,
 )
+from utils.logout_button import logout_button
 
-st.set_page_config(page_title=f"{BRAND} — Accede a tu cuenta", layout="wide")
+
+def _go_leads():
+    from utils.nav import go as _go
+
+    _go(LEADS_PAGE_LABEL)
+
+
+def _go_assistant():
+    from utils.nav import go as _go
+
+    _go(ASSISTANT_PAGE_LABEL)
+
+
+def _go_pair(label, path=None):
+    from utils.nav import go as _go
+
+    try:
+        _go(label)
+    except Exception:
+        if path:
+            _go(path)
+
+
+def _card_primary(title, desc, on_click):
+    st.button(f"{title}\n{desc}", use_container_width=True, on_click=on_click)
+
+
+def _card_secondary(emoji, title, desc, on_click):
+    st.button(
+        f"{emoji} {title}\n{desc}", use_container_width=True, on_click=on_click
+    )
+
 
 restore_session_if_allowed()
 
-st.markdown(f"# {BRAND}")
-st.subheader("Accede a tu cuenta")
+if is_authenticated():
+    st.set_page_config(page_title=f"{BRAND} — Inicio", layout="wide")
+else:
+    st.set_page_config(page_title=f"{BRAND} — Accede a tu cuenta", layout="wide")
 
 if is_authenticated():
-    st.info("Ya has iniciado sesión")
-    st.button(
-        "Ir a Búsqueda",
-        use_container_width=True,
-        on_click=go,
+    st.markdown(
+        """
+        <style>
+        .card-container .stButton>button {
+            border-radius:16px;
+            box-shadow:0 6px 24px rgba(0,0,0,.06);
+            padding:1.5rem;
+            transition:all .1s ease-in-out;
+            white-space:normal;
+        }
+        .card-container .stButton>button:hover {
+            box-shadow:0 6px 24px rgba(0,0,0,.12);
+            transform:translateY(-2px);
+        }
+        .primary-grid .stButton>button {font-size:1.25rem;}
+        .secondary-grid .stButton>button {font-size:1.05rem;padding:1rem;}
+        </style>
+        """,
+        unsafe_allow_html=True,
     )
+
+    st.markdown(f"# {BRAND}")
+    cols_header = st.columns([3, 1])
+    with cols_header[0]:
+        st.subheader("¿Qué quieres hacer hoy?")
+    with cols_header[1]:
+        st.info("Sesión activa")
+
+    st.markdown('<div class="card-container">', unsafe_allow_html=True)
+
+    st.markdown('<div class="primary-grid">', unsafe_allow_html=True)
+    cols = st.columns(2)
+    with cols[0]:
+        _card_primary(
+            "🔎 Búsqueda de leads",
+            "Encuentra y guarda leads por nicho desde Google/Maps.",
+            _go_leads,
+        )
+    with cols[1]:
+        _card_primary(
+            "🤖 Asistente virtual (beta)",
+            "Haz preguntas y lanza búsquedas guiadas con IA.",
+            _go_assistant,
+        )
+    st.markdown("</div>", unsafe_allow_html=True)
+
+    st.markdown("### Más herramientas")
+    st.markdown('<div class="secondary-grid">', unsafe_allow_html=True)
+    sec_cols = st.columns(4)
+    for i, (label, path, desc, emoji) in enumerate(SECONDARY_PAGES):
+        col = sec_cols[i % len(sec_cols)]
+        with col:
+            _card_secondary(emoji, label, desc, lambda l=label, p=path: _go_pair(l, p))
+    st.markdown("</div>", unsafe_allow_html=True)
+
+    logout_button()
+    st.markdown("</div>", unsafe_allow_html=True)
 else:
+    st.markdown(f"# {BRAND}")
+    st.subheader("Accede a tu cuenta")
+
     tabs = st.tabs(["Entrar", "Crear cuenta"])
 
     with tabs[0]:

--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -6,7 +6,16 @@ here for convenient access as ``from utils import ...``.
 
 from .style_utils import full_width_button
 from . import http_client
-from .constants import BRAND, AFTER_LOGIN_PAGE_LABEL, AFTER_LOGIN_PAGE_PATH
+from .constants import (
+    BRAND,
+    AFTER_LOGIN_PAGE_LABEL,
+    AFTER_LOGIN_PAGE_PATH,
+    LEADS_PAGE_LABEL,
+    LEADS_PAGE_PATH,
+    ASSISTANT_PAGE_LABEL,
+    ASSISTANT_PAGE_PATH,
+    SECONDARY_PAGES,
+)
 
 __all__ = [
     "full_width_button",
@@ -14,4 +23,9 @@ __all__ = [
     "BRAND",
     "AFTER_LOGIN_PAGE_LABEL",
     "AFTER_LOGIN_PAGE_PATH",
+    "LEADS_PAGE_LABEL",
+    "LEADS_PAGE_PATH",
+    "ASSISTANT_PAGE_LABEL",
+    "ASSISTANT_PAGE_PATH",
+    "SECONDARY_PAGES",
 ]

--- a/streamlit_app/utils/constants.py
+++ b/streamlit_app/utils/constants.py
@@ -5,4 +5,57 @@ BRAND = os.getenv("BRAND_NAME", "OpenSells")
 AFTER_LOGIN_PAGE_LABEL = os.getenv("AFTER_LOGIN_PAGE_LABEL", "Buscar leads")
 AFTER_LOGIN_PAGE_PATH = os.getenv("AFTER_LOGIN_PAGE_PATH", "pages/Buscar_leads.py")
 
-__all__ = ["BRAND", "AFTER_LOGIN_PAGE_LABEL", "AFTER_LOGIN_PAGE_PATH"]
+LEADS_PAGE_LABEL = os.getenv("LEADS_PAGE_LABEL", "Buscar leads")
+LEADS_PAGE_PATH = os.getenv("LEADS_PAGE_PATH", "pages/Buscar_leads.py")
+
+ASSISTANT_PAGE_LABEL = os.getenv(
+    "ASSISTANT_PAGE_LABEL", "Asistente virtual (beta)"
+)
+ASSISTANT_PAGE_PATH = os.getenv(
+    "ASSISTANT_PAGE_PATH", "pages/Asistente_virtual.py"
+)
+
+# Lista de accesos secundarios: (label, path, descripcion, emoji)
+SECONDARY_PAGES = [
+    (
+        "Nichos",
+        "pages/Nichos.py",
+        "Gestiona y elimina nichos; explora sus leads.",
+        "🗂️",
+    ),
+    (
+        "Tareas pendientes",
+        "pages/Tareas_pendientes.py",
+        "Crea, prioriza y marca tareas por lead.",
+        "✅",
+    ),
+    (
+        "Historial",
+        "pages/Historial.py",
+        "Revisa acciones recientes por lead y nicho.",
+        "🕓",
+    ),
+    (
+        "Exportaciones",
+        "pages/Exportaciones.py",
+        "Descarga CSV filtrados y combinados.",
+        "📤",
+    ),
+    (
+        "Mi cuenta / Configuración",
+        "pages/Mi_cuenta.py",
+        "Datos de usuario y preferencias.",
+        "⚙️",
+    ),
+]
+
+__all__ = [
+    "BRAND",
+    "AFTER_LOGIN_PAGE_LABEL",
+    "AFTER_LOGIN_PAGE_PATH",
+    "LEADS_PAGE_LABEL",
+    "LEADS_PAGE_PATH",
+    "ASSISTANT_PAGE_LABEL",
+    "ASSISTANT_PAGE_PATH",
+    "SECONDARY_PAGES",
+]

--- a/streamlit_app/utils/nav.py
+++ b/streamlit_app/utils/nav.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 import streamlit as st
 
-from . import AFTER_LOGIN_PAGE_LABEL, AFTER_LOGIN_PAGE_PATH
+from . import (
+    AFTER_LOGIN_PAGE_LABEL,
+    AFTER_LOGIN_PAGE_PATH,
+    LEADS_PAGE_LABEL,
+    LEADS_PAGE_PATH,
+    ASSISTANT_PAGE_LABEL,
+    ASSISTANT_PAGE_PATH,
+)
 
 # Alias retrocompatible para código legacy:
 HOME_PAGE = (AFTER_LOGIN_PAGE_LABEL or "Home")  # ej.: "Buscar leads"
@@ -15,9 +22,15 @@ _ALIASES: dict[str, str] = {
     "inicio": "Home",
     "home.py": "Home",
     "home": "Home",
-    "buscar": "Buscar leads",
-    "búsqueda": "Buscar leads",
-    "busqueda": "Buscar leads",
+    "buscar": LEADS_PAGE_LABEL,
+    "búsqueda": LEADS_PAGE_LABEL,
+    "busqueda": LEADS_PAGE_LABEL,
+    "leads": LEADS_PAGE_LABEL,
+    "buscar leads": LEADS_PAGE_LABEL,
+    "asistente": ASSISTANT_PAGE_LABEL,
+    "assistant": ASSISTANT_PAGE_LABEL,
+    "ai": ASSISTANT_PAGE_LABEL,
+    "asistente virtual": ASSISTANT_PAGE_LABEL,
 }
 
 
@@ -47,6 +60,8 @@ def go(target: str | None = None) -> None:
         f"pages/{label}.py",
         f"{label}.py",
         AFTER_LOGIN_PAGE_PATH,
+        LEADS_PAGE_PATH,
+        ASSISTANT_PAGE_PATH,
         candidate,  # por si ya era ruta válida
     ):
         if path and _try_switch(path):


### PR DESCRIPTION
## Summary
- add constants and secondary page list for streamlined navigation
- expand nav aliases and fallbacks for leads and assistant pages
- redesign Home with primary/secondary action cards and logout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bde24493b88323a0d373c32203fb36