### PR TITLE
fix(imports): eliminar ciclo utils↔nav y exports robustos de constantes

### DIFF
--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -12,7 +12,7 @@ from utils import (
     ASSISTANT_PAGE_LABEL, ASSISTANT_PAGE_PATH,
     SECONDARY_PAGES,
 )
-from utils.nav import go
+from utils.nav import go  # <- nav se importa del submódulo, no del paquete raíz
 from utils.http_client import post, login as http_login
 from utils.auth_utils import (
     is_authenticated,

--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -1,11 +1,7 @@
-# Exports robustos con defaults -> override por constants.py
-
-from .style_utils import full_width_button
-from . import http_client
-
+# Exports robustos: defaults seguros + override desde constants.py.
 import os as _os
 
-# 1) Defaults seguros (siempre definidos)
+# Defaults (siempre definidos)
 BRAND = _os.getenv("BRAND_NAME", "OpenSells")
 
 AFTER_LOGIN_PAGE_LABEL = _os.getenv("AFTER_LOGIN_PAGE_LABEL", "Buscar leads")
@@ -15,35 +11,34 @@ LEADS_PAGE_LABEL = _os.getenv("LEADS_PAGE_LABEL", "Buscar leads")
 LEADS_PAGE_PATH  = _os.getenv("LEADS_PAGE_PATH",  "pages/Buscar_leads.py")
 
 ASSISTANT_PAGE_LABEL = _os.getenv("ASSISTANT_PAGE_LABEL", "Asistente virtual (beta)")
-ASSISTANT_PAGE_PATH  = _os.getenv("ASSISTANT_PAGE_PATH",  "pages/Asistente_virtual.py")
+ASSISTANT_PAGE_PATH  = _os.getenv("ASSISTANT_PAGE_PATH", "pages/Asistente_virtual.py")
 
 SECONDARY_PAGES = []
 
-# 2) Override con valores reales si constants.py existe
+# Override si constants.py existe
 try:
     from . import constants as _c
-    BRAND = getattr(_c, "BRAND", BRAND)
 
-    AFTER_LOGIN_PAGE_LABEL = getattr(_c, "AFTER_LOGIN_PAGE_LABEL", AFTER_LOGIN_PAGE_LABEL)
-    AFTER_LOGIN_PAGE_PATH  = getattr(_c, "AFTER_LOGIN_PAGE_PATH",  AFTER_LOGIN_PAGE_PATH)
+    def _ov(name, current):
+        return getattr(_c, name, current)
 
-    LEADS_PAGE_LABEL = getattr(_c, "LEADS_PAGE_LABEL", LEADS_PAGE_LABEL)
-    LEADS_PAGE_PATH  = getattr(_c, "LEADS_PAGE_PATH",  LEADS_PAGE_PATH)
-
-    ASSISTANT_PAGE_LABEL = getattr(_c, "ASSISTANT_PAGE_LABEL", ASSISTANT_PAGE_LABEL)
-    ASSISTANT_PAGE_PATH  = getattr(_c, "ASSISTANT_PAGE_PATH",  ASSISTANT_PAGE_PATH)
-
-    SECONDARY_PAGES = getattr(_c, "SECONDARY_PAGES", SECONDARY_PAGES)
+    BRAND = _ov("BRAND", BRAND)
+    AFTER_LOGIN_PAGE_LABEL = _ov("AFTER_LOGIN_PAGE_LABEL", AFTER_LOGIN_PAGE_LABEL)
+    AFTER_LOGIN_PAGE_PATH  = _ov("AFTER_LOGIN_PAGE_PATH",  AFTER_LOGIN_PAGE_PATH)
+    LEADS_PAGE_LABEL       = _ov("LEADS_PAGE_LABEL",       LEADS_PAGE_LABEL)
+    LEADS_PAGE_PATH        = _ov("LEADS_PAGE_PATH",        LEADS_PAGE_PATH)
+    ASSISTANT_PAGE_LABEL   = _ov("ASSISTANT_PAGE_LABEL",   ASSISTANT_PAGE_LABEL)
+    ASSISTANT_PAGE_PATH    = _ov("ASSISTANT_PAGE_PATH",    ASSISTANT_PAGE_PATH)
+    SECONDARY_PAGES        = _ov("SECONDARY_PAGES",        SECONDARY_PAGES)
 except Exception:
-    # si falla, mantenemos los defaults y no crasheamos
+    # mantenemos defaults sin romper arranque
     pass
 
 __all__ = [
-    "full_width_button",
-    "http_client",
     "BRAND",
     "AFTER_LOGIN_PAGE_LABEL", "AFTER_LOGIN_PAGE_PATH",
     "LEADS_PAGE_LABEL", "LEADS_PAGE_PATH",
     "ASSISTANT_PAGE_LABEL", "ASSISTANT_PAGE_PATH",
     "SECONDARY_PAGES",
 ]
+

--- a/streamlit_app/utils/constants.py
+++ b/streamlit_app/utils/constants.py
@@ -16,10 +16,10 @@ ASSISTANT_PAGE_PATH  = os.getenv("ASSISTANT_PAGE_PATH",  "pages/Asistente_virtua
 
 # Accesos secundarios (label, path, descripción, emoji)
 SECONDARY_PAGES = [
-    ("Nichos", "pages/Nichos.py", "Gestiona y elimina nichos; explora sus leads.", "🗂️"),
-    ("Tareas pendientes", "pages/Tareas_pendientes.py", "Crea, prioriza y marca tareas.", "✅"),
-    ("Historial", "pages/Historial.py", "Acciones recientes por lead y nicho.", "🕓"),
-    ("Exportaciones", "pages/Exportaciones.py", "Descarga CSV filtrados y combinados.", "📤"),
-    ("Mi cuenta / Configuración", "pages/Mi_cuenta.py", "Datos de usuario y preferencias.", "⚙️"),
+    ("Nichos", "pages/Nichos.py", "Gestiona y explora nichos y leads.", "🗂️"),
+    ("Tareas pendientes", "pages/Tareas_pendientes.py", "Prioriza y marca tareas.", "✅"),
+    ("Historial", "pages/Historial.py", "Acciones recientes y cambios.", "🕓"),
+    ("Exportaciones", "pages/Exportaciones.py", "Descarga CSV filtrados.", "📤"),
+    ("Mi cuenta / Configuración", "pages/Mi_cuenta.py", "Preferencias y sesión.", "⚙️"),
 ]
 

--- a/streamlit_app/utils/nav.py
+++ b/streamlit_app/utils/nav.py
@@ -2,20 +2,19 @@ from __future__ import annotations
 
 import streamlit as st
 
-from . import AFTER_LOGIN_PAGE_LABEL, AFTER_LOGIN_PAGE_PATH
+# Import directo desde constants: evita import circular
+from .constants import (
+    AFTER_LOGIN_PAGE_LABEL,
+    AFTER_LOGIN_PAGE_PATH,
+    LEADS_PAGE_PATH,
+    ASSISTANT_PAGE_PATH,
+)
 
-# Importa opcionales si existen
-try:  # pragma: no cover - defensa ante despliegues parciales
-    from . import LEADS_PAGE_PATH, ASSISTANT_PAGE_PATH
-except Exception:  # pragma: no cover - fallback seguro
-    LEADS_PAGE_PATH = None
-    ASSISTANT_PAGE_PATH = None
-
-HOME_PAGE = (AFTER_LOGIN_PAGE_LABEL or "Home")
+HOME_PAGE = AFTER_LOGIN_PAGE_LABEL or "Home"
 __all__ = ["go", "HOME_PAGE"]
 
-_ALIASES = {
-    "app": "Home", "app.py": "Home", "inicio": "Home", "home.py": "Home", "home": "Home",
+_ALIASES: dict[str, str] = {
+    "app": "Home", "app.py": "Home", "home": "Home", "inicio": "Home",
     "leads": "Buscar leads", "buscar leads": "Buscar leads",
     "asistente": "Asistente virtual (beta)", "assistant": "Asistente virtual (beta)",
     "ai": "Asistente virtual (beta)", "asistente virtual": "Asistente virtual (beta)",
@@ -31,19 +30,27 @@ def _try_switch(target: str) -> bool:
 
 
 def go(target: str | None = None) -> None:
+    """
+    Navega por label (preferente) o por ruta.
+    Si target es None, usa HOME_PAGE.
+    """
     candidate = (target or HOME_PAGE or "").strip() or "Home"
+    # 1) Intento por alias/label
     label = _ALIASES.get(candidate.lower(), candidate)
     if _try_switch(label):
         return
+    # 2) Rutas probables + fallbacks
     for path in (
         f"pages/{label}.py",
         f"{label}.py",
         AFTER_LOGIN_PAGE_PATH,
         LEADS_PAGE_PATH,
         ASSISTANT_PAGE_PATH,
-        candidate,
+        candidate,  # por si ya era una ruta válida
     ):
         if path and _try_switch(path):
             return
+    # 3) Último recurso: no dejes la app rota
     st.toast("No se encontró la página de destino; recargando…")
     st.rerun()
+


### PR DESCRIPTION
## Summary
- replace fragile constants with robust defaults and env overrides
- drop cross-imports in utils to avoid circular nav dependency
- import navigation helper from utils.nav in frontend views

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdeba5d3908323923b2e114804fb9e