### PR TITLE
refactor: simplify utils package imports

### DIFF
--- a/streamlit_app/Home.py
+++ b/streamlit_app/Home.py
@@ -6,7 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from utils.constants import (
+from streamlit_app.utils.constants import (
     BRAND,
     LEADS_PAGE_LABEL,
     LEADS_PAGE_PATH,
@@ -14,30 +14,30 @@ from utils.constants import (
     ASSISTANT_PAGE_PATH,
     SECONDARY_PAGES,
 )
-from utils.nav import go  # <- nav se importa del submódulo, no del paquete raíz
-from utils.http_client import post, login as http_login
-from utils.auth_utils import (
+from streamlit_app.utils.nav import go  # <- nav se importa del submódulo, no del paquete raíz
+from streamlit_app.utils.http_client import post, login as http_login
+from streamlit_app.utils.auth_utils import (
     is_authenticated,
     save_session,
     restore_session_if_allowed,
 )
-from utils.logout_button import logout_button
+from streamlit_app.utils.logout_button import logout_button
 
 
 def _go_leads():
-    from utils.nav import go as _go
+    from streamlit_app.utils.nav import go as _go
 
     _go(LEADS_PAGE_LABEL)
 
 
 def _go_assistant():
-    from utils.nav import go as _go
+    from streamlit_app.utils.nav import go as _go
 
     _go(ASSISTANT_PAGE_LABEL)
 
 
 def _go_pair(label, path=None):
-    from utils.nav import go as _go
+    from streamlit_app.utils.nav import go as _go
 
     try:
         _go(label)

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -24,7 +24,7 @@ ensure_session_or_redirect()
 token = st.session_state.get("auth_token")
 user = st.session_state.get("user")
 if not user:
-    from streamlit_app.utils import http_client
+    import streamlit_app.utils.http_client as http_client
     resp_user = http_client.get("/me")
     if resp_user is not None and resp_user.status_code == 200:
         user = resp_user.json()

--- a/streamlit_app/assistant_api.py
+++ b/streamlit_app/assistant_api.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional, List
 
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 
 EXTRAER_LEADS_MSG = (
     "🚧 Esta funcionalidad desde el asistente estará disponible próximamente. "

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
 
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 
 from streamlit_app.cache_utils import cached_get, get_openai_client, auth_headers, limpiar_cache
 from streamlit_app.plan_utils import subscription_cta

--- a/streamlit_app/pages/2_Asistente_Virtual.py
+++ b/streamlit_app/pages/2_Asistente_Virtual.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 
 from streamlit_app.cache_utils import cached_get, get_openai_client
 from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.assistant_api import (
     ASSISTANT_EXTRACTION_ENABLED,
     EXTRAER_LEADS_MSG,

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -23,7 +23,7 @@ from streamlit_app.cache_utils import (
     limpiar_cache,
 )
 from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.utils.auth_session import (
     is_authenticated,
     remember_current_page,

--- a/streamlit_app/pages/4_Tareas.py
+++ b/streamlit_app/pages/4_Tareas.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 
 from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
 from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token
 from streamlit_app.utils.logout_button import logout_button
 # ────────────────── Config ──────────────────────────

--- a/streamlit_app/pages/5_Exportaciones.py
+++ b/streamlit_app/pages/5_Exportaciones.py
@@ -1,6 +1,6 @@
 import streamlit as st
 
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token
 from streamlit_app.utils.logout_button import logout_button
 

--- a/streamlit_app/pages/6_Emails.py
+++ b/streamlit_app/pages/6_Emails.py
@@ -1,7 +1,7 @@
 import streamlit as st
 
 from streamlit_app.plan_utils import tiene_suscripcion_activa, subscription_cta
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token
 from streamlit_app.utils.logout_button import logout_button
 

--- a/streamlit_app/pages/7_Suscripcion.py
+++ b/streamlit_app/pages/7_Suscripcion.py
@@ -5,7 +5,7 @@ import streamlit as st
 import requests
 from dotenv import load_dotenv
 
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.plan_utils import force_redirect
 from streamlit_app.utils.plans import PLANS_FEATURES
 from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token

--- a/streamlit_app/pages/8_Mi_Cuenta.py
+++ b/streamlit_app/pages/8_Mi_Cuenta.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from json import JSONDecodeError
 
 from streamlit_app.cache_utils import cached_get, cached_post, limpiar_cache
-from streamlit_app.utils import http_client
+import streamlit_app.utils.http_client as http_client
 from streamlit_app.plan_utils import subscription_cta, force_redirect
 from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token
 from streamlit_app.utils.logout_button import logout_button

--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -1,44 +1,14 @@
-# Exports robustos: defaults seguros + override desde constants.py.
-import os as _os
+"""Utility helpers for the Streamlit frontend.
 
-# Defaults (siempre definidos)
-BRAND = _os.getenv("BRAND_NAME", "OpenSells")
+All constants, functions and classes should be imported from their
+dedicated submodules, e.g.::
 
-AFTER_LOGIN_PAGE_LABEL = _os.getenv("AFTER_LOGIN_PAGE_LABEL", "Buscar leads")
-AFTER_LOGIN_PAGE_PATH  = _os.getenv("AFTER_LOGIN_PAGE_PATH",  "pages/Buscar_leads.py")
+    from streamlit_app.utils.constants import BRAND
+    from streamlit_app.utils.nav import go
 
-LEADS_PAGE_LABEL = _os.getenv("LEADS_PAGE_LABEL", "Buscar leads")
-LEADS_PAGE_PATH  = _os.getenv("LEADS_PAGE_PATH",  "pages/Buscar_leads.py")
+This ``__init__`` intentionally exposes no additional symbols to avoid
+import-time side effects and circular dependencies.
+"""
 
-ASSISTANT_PAGE_LABEL = _os.getenv("ASSISTANT_PAGE_LABEL", "Asistente virtual (beta)")
-ASSISTANT_PAGE_PATH  = _os.getenv("ASSISTANT_PAGE_PATH", "pages/Asistente_virtual.py")
-
-SECONDARY_PAGES = []
-
-# Override si constants.py existe
-try:
-    from . import constants as _c
-
-    def _ov(name, current):
-        return getattr(_c, name, current)
-
-    BRAND = _ov("BRAND", BRAND)
-    AFTER_LOGIN_PAGE_LABEL = _ov("AFTER_LOGIN_PAGE_LABEL", AFTER_LOGIN_PAGE_LABEL)
-    AFTER_LOGIN_PAGE_PATH  = _ov("AFTER_LOGIN_PAGE_PATH",  AFTER_LOGIN_PAGE_PATH)
-    LEADS_PAGE_LABEL       = _ov("LEADS_PAGE_LABEL",       LEADS_PAGE_LABEL)
-    LEADS_PAGE_PATH        = _ov("LEADS_PAGE_PATH",        LEADS_PAGE_PATH)
-    ASSISTANT_PAGE_LABEL   = _ov("ASSISTANT_PAGE_LABEL",   ASSISTANT_PAGE_LABEL)
-    ASSISTANT_PAGE_PATH    = _ov("ASSISTANT_PAGE_PATH",    ASSISTANT_PAGE_PATH)
-    SECONDARY_PAGES        = _ov("SECONDARY_PAGES",        SECONDARY_PAGES)
-except Exception:
-    # mantenemos defaults sin romper arranque
-    pass
-
-__all__ = [
-    "BRAND",
-    "AFTER_LOGIN_PAGE_LABEL", "AFTER_LOGIN_PAGE_PATH",
-    "LEADS_PAGE_LABEL", "LEADS_PAGE_PATH",
-    "ASSISTANT_PAGE_LABEL", "ASSISTANT_PAGE_PATH",
-    "SECONDARY_PAGES",
-]
+__all__: list[str] = []
 


### PR DESCRIPTION
## Summary
- remove `streamlit_app.utils` package reexports
- import constants and http client from explicit submodules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdfd65e6688323a46c1fa32a46a8a4