### PR TITLE
feat: centralize app constants

### DIFF
--- a/streamlit_app/utils/__init__.py
+++ b/streamlit_app/utils/__init__.py
@@ -1,14 +1,2 @@
-"""Utility helpers for the Streamlit frontend.
-
-All constants, functions and classes should be imported from their
-dedicated submodules, e.g.::
-
-    from streamlit_app.utils.constants import BRAND
-    from streamlit_app.utils.nav import go
-
-This ``__init__`` intentionally exposes no additional symbols to avoid
-import-time side effects and circular dependencies.
-"""
-
 __all__: list[str] = []
 

--- a/streamlit_app/utils/constants.py
+++ b/streamlit_app/utils/constants.py
@@ -1,25 +1,77 @@
+"""Centralized constants for the Streamlit frontend.
+
+All values can be overridden via environment variables to keep the
+configuration flexible across deployments. Every path points by default to a
+file within ``streamlit_app/pages``.
+"""
+
+from __future__ import annotations
+
 import os
 
-# Marca
+
+# Nombre de la marca que se muestra en la interfaz.
 BRAND = os.getenv("BRAND_NAME", "OpenSells")
 
-# Navegación post-login por defecto
-AFTER_LOGIN_PAGE_LABEL = os.getenv("AFTER_LOGIN_PAGE_LABEL", "Buscar leads")
-AFTER_LOGIN_PAGE_PATH  = os.getenv("AFTER_LOGIN_PAGE_PATH",  "pages/Buscar_leads.py")
 
-# Páginas principales de la Home
-LEADS_PAGE_LABEL     = os.getenv("LEADS_PAGE_LABEL",     "Buscar leads")
-LEADS_PAGE_PATH      = os.getenv("LEADS_PAGE_PATH",      "pages/Buscar_leads.py")
+# Datos de navegación principales de la aplicación.
+LEADS_PAGE_LABEL = os.getenv("LEADS_PAGE_LABEL", "Búsqueda de leads")
+LEADS_PAGE_PATH = os.getenv("LEADS_PAGE_PATH", "pages/1_Busqueda.py")
 
-ASSISTANT_PAGE_LABEL = os.getenv("ASSISTANT_PAGE_LABEL", "Asistente virtual (beta)")
-ASSISTANT_PAGE_PATH  = os.getenv("ASSISTANT_PAGE_PATH",  "pages/Asistente_virtual.py")
+ASSISTANT_PAGE_LABEL = os.getenv(
+    "ASSISTANT_PAGE_LABEL", "Asistente virtual (beta)"
+)
+ASSISTANT_PAGE_PATH = os.getenv(
+    "ASSISTANT_PAGE_PATH", "pages/2_Asistente_Virtual.py"
+)
 
-# Accesos secundarios (label, path, descripción, emoji)
-SECONDARY_PAGES = [
-    ("Nichos", "pages/Nichos.py", "Gestiona y explora nichos y leads.", "🗂️"),
-    ("Tareas pendientes", "pages/Tareas_pendientes.py", "Prioriza y marca tareas.", "✅"),
-    ("Historial", "pages/Historial.py", "Acciones recientes y cambios.", "🕓"),
-    ("Exportaciones", "pages/Exportaciones.py", "Descarga CSV filtrados.", "📤"),
-    ("Mi cuenta / Configuración", "pages/Mi_cuenta.py", "Preferencias y sesión.", "⚙️"),
+
+# Página a la que se redirige tras un login satisfactorio.
+AFTER_LOGIN_PAGE_LABEL = os.getenv(
+    "AFTER_LOGIN_PAGE_LABEL", LEADS_PAGE_LABEL
+)
+AFTER_LOGIN_PAGE_PATH = os.getenv(
+    "AFTER_LOGIN_PAGE_PATH", LEADS_PAGE_PATH
+)
+
+
+# Accesos secundarios opcionales mostrados en la página principal.
+# El formato es una lista de tuplas: (label, path, descripción, emoji).
+# Mantener la lista vacía por defecto y dejar ejemplos comentados para futuras
+# extensiones.
+SECONDARY_PAGES: list[tuple[str, str, str, str]] = [
+    # ("Nichos", "pages/3_Mis_Nichos.py", "Gestiona y explora nichos y leads.", "🗂️"),
+    # (
+    #     "Tareas pendientes",
+    #     "pages/4_Tareas.py",
+    #     "Prioriza y marca tareas.",
+    #     "✅",
+    # ),
+    # (
+    #     "Exportaciones",
+    #     "pages/5_Exportaciones.py",
+    #     "Descarga CSV filtrados.",
+    #     "📤",
+    # ),
+    # ("Emails", "pages/6_Emails.py", "Gestiona envíos de correos.", "✉️"),
+    # ("Suscripción", "pages/7_Suscripcion.py", "Gestiona tu plan.", "💳"),
+    # (
+    #     "Mi cuenta / Configuración",
+    #     "pages/8_Mi_Cuenta.py",
+    #     "Preferencias y sesión.",
+    #     "⚙️",
+    # ),
+]
+
+
+__all__ = [
+    "BRAND",
+    "LEADS_PAGE_LABEL",
+    "LEADS_PAGE_PATH",
+    "ASSISTANT_PAGE_LABEL",
+    "ASSISTANT_PAGE_PATH",
+    "AFTER_LOGIN_PAGE_LABEL",
+    "AFTER_LOGIN_PAGE_PATH",
+    "SECONDARY_PAGES",
 ]
 


### PR DESCRIPTION
## Summary
- centralize frontend labels and navigation paths in a dedicated constants module
- strip utils package to avoid side effects

## Testing
- `pytest`
- `rg "from utils import" -n`
- `rg "LEADS_PAGE_LABEL" -n streamlit_app/utils/constants.py`


------
https://chatgpt.com/codex/tasks/task_e_68be00aa2ab8832388470f3dd409daae