### PR TITLE
Drop legacy users tables

### DIFF
--- a/AUDITORIA_TABLAS.md
+++ b/AUDITORIA_TABLAS.md
@@ -1,0 +1,15 @@
+# Auditoría de tablas
+
+## Tablas activas
+- usuarios
+- user_usage_monthly
+- leads_extraidos
+- lead_tarea
+- lead_historial
+- lead_nota
+- lead_info_extra
+- usuario_memoria
+
+## Tablas legadas eliminadas
+- users (reemplazada por `usuarios`)
+- usage_counters (reemplazada por `user_usage_monthly`)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Integra autenticación JWT, multitenencia mediante `user_email_lower` y planes d
 - **Migración a emails en minúsculas:** script `backend/scripts/migrate_emails_lowercase.py` para poblar e indexar campos `user_email_lower`.
 - **Matriz de planes centralizada:** `backend/core/plans.py` y `backend/core/usage.py` definen límites y registran consumo mensual.
 - **Suspensión de usuarios:** columna `suspendido` en `usuarios` y guard que bloquea acceso si está activa.
+- **Depuración de tablas legado:** eliminadas referencias a `users` y `usage_counters`; la info de usuarios se gestiona solo en `usuarios` y el uso mensual en `user_usage_monthly`.
 
 ## 📊 Estado del proyecto
 

--- a/backend/alembic/versions/20250115_email_lower_unique_index.py
+++ b/backend/alembic/versions/20250115_email_lower_unique_index.py
@@ -26,7 +26,7 @@ def upgrade():
         with op.get_context().autocommit_block():
             conn.execute(
                 text(
-                    "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_users_email_lower ON usuarios ((lower(email)))"
+                    "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ix_usuarios_email_lower ON usuarios ((lower(email)))"
                 )
             )
     except Exception as exc:  # pragma: no cover - depends on DB state
@@ -46,5 +46,5 @@ def downgrade():
     if conn.dialect.name != "postgresql":
         return
     with op.get_context().autocommit_block():
-        conn.execute(text("DROP INDEX IF EXISTS ix_users_email_lower"))
+        conn.execute(text("DROP INDEX IF EXISTS ix_usuarios_email_lower"))
 

--- a/backend/alembic/versions/20250910_drop_legacy_users_usage_counters.py
+++ b/backend/alembic/versions/20250910_drop_legacy_users_usage_counters.py
@@ -1,0 +1,32 @@
+"""
+Revision ID: 20250910_drop_legacy_users_usage_counters
+Revises: 20250201_add_suspendido_column
+Create Date: 2025-09-10
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20250910_drop_legacy_users_usage_counters"
+down_revision = "20250201_add_suspendido_column"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    for tbl in ("users", "usage_counters"):
+        bind.execute(
+            sa.text(
+                "DO $$ BEGIN IF EXISTS (SELECT 1 FROM information_schema.tables "
+                "WHERE table_schema='public' AND table_name=:t) THEN "
+                "EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(:t) || ' CASCADE'; "
+                "END IF; END $$;"
+            ),
+            {"t": tbl},
+        )
+
+
+def downgrade():
+    pass

--- a/tests/test_no_legacy_tables.py
+++ b/tests/test_no_legacy_tables.py
@@ -1,0 +1,87 @@
+import os
+import subprocess
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.main import app, get_db
+from backend.database import Base
+from backend.models import Usuario, LeadExtraido
+from backend.auth import hashear_password
+
+
+def test_no_legacy_tables_and_grep():
+    from backend.models import Base as ModelsBase
+    assert "users" not in ModelsBase.metadata.tables
+    assert "usage_counters" not in ModelsBase.metadata.tables
+
+    result = subprocess.run(
+        ["rg", "--files-with-matches", r"\b(users|usage_counters)\b", "backend"],
+        capture_output=True,
+        text=True,
+    )
+    files = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    allow = {"backend/alembic/versions/20250910_drop_legacy_users_usage_counters.py"}
+    assert set(files).issubset(allow)
+
+
+def test_endpoints_do_not_touch_legacy_tables(caplog):
+    os.environ.setdefault("OPENAI_API_KEY", "test")
+    os.environ.setdefault("DATABASE_URL", "sqlite://")
+    os.environ.setdefault("ALLOW_ANON_USER", "1")
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=True,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    caplog.set_level("INFO")
+    client = TestClient(app)
+
+    with TestingSessionLocal() as db:
+        user = Usuario(email="tester@example.com", hashed_password=hashear_password("secret"))
+        db.add(user)
+        db.flush()
+        lead = LeadExtraido(
+            user_email=user.email,
+            user_email_lower=user.email.lower(),
+            url="example.com",
+            nicho="n",
+            nicho_original="n",
+        )
+        db.add(lead)
+        db.commit()
+        lead_id = lead.id
+
+    resp = client.post("/login", json={"email": "tester@example.com", "password": "secret"})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    r2 = client.patch(
+        f"/leads/{lead_id}/estado_contacto",
+        json={"estado_contacto": "contactado"},
+        headers=headers,
+    )
+    assert r2.status_code == 200
+
+    r3 = client.get("/mi_plan", headers=headers)
+    assert r3.status_code == 200
+
+    assert "users" not in caplog.text
+    assert "usage_counters" not in caplog.text
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- rename case-insensitive email index to avoid legacy `users` naming
- drop `users`/`usage_counters` tables conditionally via migration
- guard against reintroduction with tests and docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1a365be9483238df901116fe98940