### PR TITLE
chore(alembic): add ini/env, merge heads, helper scripts & docs

### DIFF
--- a/.github/workflows/alembic.yml
+++ b/.github/workflows/alembic.yml
@@ -1,0 +1,19 @@
+name: Alembic
+
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - name: ensure single head
+        env:
+          DATABASE_URL: postgresql://user:pass@localhost/db
+        run: |
+          heads=$(alembic heads | tee /tmp/heads.txt | wc -l)
+          test "$heads" -eq 1

--- a/AUDITORIA_TABLAS.md
+++ b/AUDITORIA_TABLAS.md
@@ -21,3 +21,17 @@
 ## Tablas legadas eliminadas
 - users (reemplazada por `usuarios`)
 - usage_counters (reemplazada por `user_usage_monthly`)
+
+## Recrear esquema de BD (Alembic)
+
+1. `pip install -r requirements.txt`
+2. Definir `DATABASE_URL` (añade `?sslmode=require` si el host lo necesita)
+3. `alembic upgrade head`
+
+Para reiniciar una base usa otra instancia o ejecuta:
+```sql
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+```
+
+Verifica con `alembic current` y lista tablas (`\\dt` en `psql`). No compartas credenciales en el repositorio.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,39 @@ Verificación rápida en producción:
 SELECT indexname FROM pg_indexes WHERE tablename IN ('usuarios','leads_extraidos');
 ```
 
+## 🔄 Recrear esquema de BD (Alembic)
+
+1. Instala dependencias:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Define la URL de la base de datos (agrega `?sslmode=require` si usas Render u otro host que requiera SSL):
+   ```bash
+   # Unix/macOS
+   export DATABASE_URL="postgresql://usuario:password@host/db?sslmode=require"
+   # Windows CMD
+   set DATABASE_URL=postgresql://usuario:password@host/db?sslmode=require
+   # PowerShell
+   $env:DATABASE_URL="postgresql://usuario:password@host/db?sslmode=require"
+   ```
+3. Ejecuta las migraciones:
+   ```bash
+   alembic upgrade head
+   ```
+
+Para reiniciar una base de datos existente usa una nueva base o ejecuta:
+```sql
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+```
+
+Verifica el estado con:
+```bash
+alembic current
+```
+y lista las tablas con tu cliente (`\\dt` en `psql`).
+No compartas credenciales reales en commits ni PRs.
+
 ## 🔑 Variables de entorno
 
 Copia `.env.example` a `.env` y completa las claves necesarias (PostgreSQL, Stripe, etc.):

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,33 @@
+[alembic]
+script_location = backend/alembic
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+
+[formatter_generic]
+format = %(levelname)-5s [%(name)s] %(message)s

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,55 @@
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import create_engine, pool
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+from backend.database import Base
+
+# Use metadata from Base
+target_metadata = Base.metadata
+
+# Read database URL from environment
+db_url = os.environ.get("DATABASE_URL")
+if not db_url:
+    raise RuntimeError("DATABASE_URL no está definida")
+if "sslmode=" not in db_url and ("render.com" in db_url or "ssl" in db_url):
+    sep = "&" if "?" in db_url else "?"
+    db_url = f"{db_url}{sep}sslmode=require"
+config.set_main_option("sqlalchemy.url", db_url)
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        compare_type=True,
+        compare_server_default=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online():
+    connectable = create_engine(
+        config.get_main_option("sqlalchemy.url"),
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/versions/20240101_initial_schema.py
+++ b/backend/alembic/versions/20240101_initial_schema.py
@@ -1,0 +1,151 @@
+"""initial schema"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '20240101_initial_schema'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'usuarios',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('email', sa.String(length=255), nullable=False),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=False),
+        sa.Column('hashed_password', sa.String(length=255), nullable=False),
+        sa.Column('fecha_creacion', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.Column('suspendido', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    )
+    op.create_index('ix_usuarios_email_lower', 'usuarios', ['user_email_lower'], unique=True)
+
+    op.create_table(
+        'leads_extraidos',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=False),
+        sa.Column('dominio', sa.String(length=255), nullable=False),
+        sa.Column('url', sa.Text()),
+        sa.Column('telefono', sa.String(length=50)),
+        sa.Column('email', sa.String(length=255)),
+        sa.Column('creado_en', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.UniqueConstraint('user_email_lower', 'dominio', name='uix_leads_usuario_dominio'),
+    )
+    op.create_index('ix_leads_extraidos_user_email_lower', 'leads_extraidos', ['user_email_lower'])
+
+    op.create_table(
+        'lead_tarea',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=False),
+        sa.Column('dominio', sa.String(length=255)),
+        sa.Column('texto', sa.Text()),
+        sa.Column('fecha', sa.DateTime()),
+        sa.Column('completado', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+        sa.Column('timestamp', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+        sa.Column('tipo', sa.String(length=50)),
+        sa.Column('nicho', sa.String(length=255)),
+        sa.Column('prioridad', sa.String(length=10)),
+        sa.Column('auto', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    )
+    op.create_index('ix_lead_tarea_user_email_lower', 'lead_tarea', ['user_email_lower'])
+    op.create_index(
+        'ix_lead_tarea_user_dom_comp_prio_fecha_ts',
+        'lead_tarea',
+        ['user_email_lower', 'dominio', 'completado', 'prioridad', 'fecha', 'timestamp']
+    )
+
+    op.create_table(
+        'lead_nota',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=True),
+        sa.Column('url', sa.Text()),
+        sa.Column('nota', sa.Text()),
+    )
+    op.create_index('ix_lead_nota_user_email_lower_url', 'lead_nota', ['user_email_lower', 'url'])
+
+    op.create_table(
+        'lead_info_extra',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=True),
+        sa.Column('dominio', sa.String(length=255)),
+        sa.Column('clave', sa.String(length=100)),
+        sa.Column('valor', sa.Text()),
+    )
+    op.create_index('ix_lead_info_extra_user_email_lower', 'lead_info_extra', ['user_email_lower'])
+
+    op.create_table(
+        'historial',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=True),
+        sa.Column('mensaje', sa.Text()),
+        sa.Column('creado_en', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index('ix_historial_user_email_lower', 'historial', ['user_email_lower'])
+
+    op.create_table(
+        'lead_estado',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_email_lower', sa.String(length=255), nullable=False),
+        sa.Column('dominio', sa.String(length=255), nullable=False),
+        sa.Column('estado', sa.String(length=50)),
+        sa.UniqueConstraint('user_email_lower', 'dominio', name='uix_lead_estado_usuario_dominio'),
+    )
+    op.create_index('ix_lead_estado_user_email_lower', 'lead_estado', ['user_email_lower'])
+
+    op.create_table(
+        'usuario_memoria',
+        sa.Column('user_email_lower', sa.String(length=255), primary_key=True),
+        sa.Column('memoria', sa.Text()),
+        sa.Column('actualizado_en', sa.DateTime(), server_default=sa.text('now()'), nullable=False),
+    )
+
+    op.create_table(
+        'usage_counters',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer),
+        sa.Column('metric', sa.String(length=50)),
+        sa.Column('period_key', sa.String(length=20)),
+        sa.Column('valor', sa.Integer, server_default=sa.text('0')),
+        sa.UniqueConstraint('user_id', 'metric', 'period_key', name='uix_usage_counter'),
+    )
+    op.create_index(
+        'idx_usage_counters_user_metric_period',
+        'usage_counters',
+        ['user_id', 'metric', 'period_key']
+    )
+
+    op.create_table(
+        'user_usage_monthly',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('user_id', sa.Integer),
+        sa.Column('period_yyyymm', sa.String(length=6)),
+        sa.Column('leads', sa.Integer, server_default=sa.text('0')),
+        sa.Column('ia_msgs', sa.Integer, server_default=sa.text('0')),
+        sa.Column('exports', sa.Integer, server_default=sa.text('0')),
+        sa.UniqueConstraint('user_id', 'period_yyyymm', name='uix_user_usage_monthly'),
+    )
+
+
+def downgrade():
+    op.drop_table('user_usage_monthly')
+    op.drop_index('idx_usage_counters_user_metric_period', table_name='usage_counters')
+    op.drop_table('usage_counters')
+    op.drop_table('usuario_memoria')
+    op.drop_index('ix_lead_estado_user_email_lower', table_name='lead_estado')
+    op.drop_table('lead_estado')
+    op.drop_index('ix_historial_user_email_lower', table_name='historial')
+    op.drop_table('historial')
+    op.drop_index('ix_lead_info_extra_user_email_lower', table_name='lead_info_extra')
+    op.drop_table('lead_info_extra')
+    op.drop_index('ix_lead_nota_user_email_lower_url', table_name='lead_nota')
+    op.drop_table('lead_nota')
+    op.drop_index('ix_lead_tarea_user_dom_comp_prio_fecha_ts', table_name='lead_tarea')
+    op.drop_index('ix_lead_tarea_user_email_lower', table_name='lead_tarea')
+    op.drop_table('lead_tarea')
+    op.drop_index('ix_leads_extraidos_user_email_lower', table_name='leads_extraidos')
+    op.drop_table('leads_extraidos')
+    op.drop_index('ix_usuarios_email_lower', table_name='usuarios')
+    op.drop_table('usuarios')

--- a/backend/alembic/versions/20260601_merge_parallel_heads.py
+++ b/backend/alembic/versions/20260601_merge_parallel_heads.py
@@ -1,0 +1,15 @@
+"""merge parallel heads"""
+
+# revision identifiers, used by Alembic.
+revision = '20260601_merge_parallel_heads'
+down_revision = ('20260101_add_user_usage_monthly', '20240229_add_auto_to_lead_tarea')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/scripts/migrar_db.bat
+++ b/scripts/migrar_db.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal enabledelayedexpansion
+
+if "%DATABASE_URL%"=="" (
+  echo ERROR: DATABASE_URL no está definida
+  exit /b 1
+)
+
+echo Verificando heads actuales...
+alembic heads > heads.txt
+set count=0
+for /f %%i in (heads.txt) do (
+  set /a count+=1
+  set head!count!=%%i
+)
+if %count% GTR 1 (
+  echo Hay múltiples heads: %head1% %head2%
+  echo Ejecuta: alembic merge -m "merge parallel heads" %head1% %head2%
+) else (
+  echo Head actual: %head1%
+)
+del heads.txt
+
+echo Aplicando migraciones...
+alembic upgrade head
+
+echo Heads después de migrar:
+alembic heads
+
+echo Revisa que las tablas existan en tu BD.

--- a/scripts/migrar_db.sh
+++ b/scripts/migrar_db.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$DATABASE_URL" ]; then
+  echo "ERROR: DATABASE_URL no está definida" >&2
+  exit 1
+fi
+
+echo "Verificando heads actuales..."
+HEADS=$(alembic heads | awk '{print $1}')
+COUNT=$(echo "$HEADS" | wc -w)
+echo "$HEADS"
+if [ "$COUNT" -gt 1 ]; then
+  echo "⚠️ Hay múltiples heads: $HEADS"
+  echo "Ejecuta: alembic merge -m \"merge parallel heads\" $HEADS"
+fi
+
+echo "Aplicando migraciones..."
+alembic upgrade head
+
+echo "Heads después de migrar:"
+alembic heads
+
+echo "Revisa que las tablas existan en tu BD."


### PR DESCRIPTION
## Summary
- add alembic.ini
- configure backend/alembic/env.py pointing to backend.database.Base.metadata
- merge heads 20260101_add_user_usage_monthly and 20240229_add_auto_to_lead_tarea
- add scripts/migrar_db.sh and scripts/migrar_db.bat for safe migrations
- document Alembic usage in README/AUDITORIA_TABLAS and add CI workflow

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost/db alembic heads`
- `USE_TESTCONTAINERS=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c725e030d48323913f0f0afaa6286e