### PR TITLE
fix(exportar_csv): usar columna válida en historial (user_id/user_email_lower) + introspección idempotente

### DIFF
--- a/backend/core/db_introspection.py
+++ b/backend/core/db_introspection.py
@@ -1,33 +1,23 @@
-"""Helpers de introspección de base de datos para columnas dinámicas."""
-from __future__ import annotations
-
-from typing import Set, Tuple
-
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 
-def get_table_columns(db: Session, table_name: str) -> Set[str]:
-    """Devuelve el conjunto de columnas existentes para ``table_name``."""
-    result = db.execute(
+def get_table_columns(db: Session, table_name: str) -> set[str]:
+    rows = db.execute(
         text(
             """
-            SELECT column_name
-            FROM information_schema.columns
-            WHERE table_schema = current_schema()
-              AND table_name = :table_name
-            """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = :t
+    """
         ),
-        {"table_name": table_name},
-    )
-    return {row[0] for row in result}
+        {"t": table_name},
+    ).fetchall()
+    return {r[0] for r in rows}
 
 
-def ensure_historial_user_email_lower(db: Session) -> None:
-    """Garantiza la existencia de la columna ``user_email_lower`` en ``historial``."""
-    db.execute(
-        text("ALTER TABLE historial ADD COLUMN IF NOT EXISTS user_email_lower TEXT")
-    )
+def ensure_historial_user_email_lower(db: Session):
+    db.execute(text("ALTER TABLE historial ADD COLUMN IF NOT EXISTS user_email_lower TEXT"))
     db.execute(
         text(
             "CREATE INDEX IF NOT EXISTS idx_historial_user_email_lower ON historial(user_email_lower)"
@@ -36,46 +26,34 @@ def ensure_historial_user_email_lower(db: Session) -> None:
     db.flush()
 
 
-def _get_email_lower(usuario) -> str:
-    email_lower = getattr(usuario, "user_email_lower", None)
-    if email_lower:
-        return email_lower
-    email = getattr(usuario, "email", "") or ""
-    return email.strip().lower()
-
-
-def historial_insert_params(db: Session, usuario) -> Tuple[str, dict, bool]:
-    """Determina el ``INSERT`` adecuado para ``historial`` y sus parámetros.
-
-    Devuelve una tupla ``(sql, params, has_id_column)`` donde ``has_id_column``
-    indica si la tabla posee una columna ``id`` para usar en ``RETURNING``.
+def build_historial_insert(db: Session, usuario) -> tuple[str, dict]:
     """
+    Devuelve (sql, params_base) para insertar en historial la exportación del usuario.
+    El caller debe añadir params_base['filename'] antes de ejecutar.
+    """
+    cols = get_table_columns(db, "historial")
 
-    columns = get_table_columns(db, "historial")
-    has_id = "id" in columns
-    email_lower = _get_email_lower(usuario)
-
-    if "user_id" in columns:
+    if "user_id" in cols:
         sql = "INSERT INTO historial (user_id, filename) VALUES (:uid, :filename)"
-        params = {"uid": getattr(usuario, "id", None), "filename": None}
-        return sql, params, has_id
+        params = {"uid": usuario.id}
+        return sql, params
 
-    if "user_email_lower" in columns:
-        sql = (
-            "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
-        )
-        params = {"email_lower": email_lower, "filename": None}
-        return sql, params, has_id
+    email_lower = (getattr(usuario, "email", "") or "").lower()
 
+    if "user_email_lower" in cols:
+        sql = "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
+        params = {"email_lower": email_lower}
+        return sql, params
+
+    # Fallback: crear columna y usar email_lower
     ensure_historial_user_email_lower(db)
     sql = "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
-    params = {"email_lower": email_lower, "filename": None}
-    # Tras el ALTER TABLE asumimos que sigue existiendo la columna id si antes estaba
-    return sql, params, has_id
+    params = {"email_lower": email_lower}
+    return sql, params
 
 
 __all__ = [
     "get_table_columns",
     "ensure_historial_user_email_lower",
-    "historial_insert_params",
+    "build_historial_insert",
 ]

--- a/backend/core/db_introspection.py
+++ b/backend/core/db_introspection.py
@@ -1,0 +1,81 @@
+"""Helpers de introspección de base de datos para columnas dinámicas."""
+from __future__ import annotations
+
+from typing import Set, Tuple
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+
+def get_table_columns(db: Session, table_name: str) -> Set[str]:
+    """Devuelve el conjunto de columnas existentes para ``table_name``."""
+    result = db.execute(
+        text(
+            """
+            SELECT column_name
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND table_name = :table_name
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return {row[0] for row in result}
+
+
+def ensure_historial_user_email_lower(db: Session) -> None:
+    """Garantiza la existencia de la columna ``user_email_lower`` en ``historial``."""
+    db.execute(
+        text("ALTER TABLE historial ADD COLUMN IF NOT EXISTS user_email_lower TEXT")
+    )
+    db.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS idx_historial_user_email_lower ON historial(user_email_lower)"
+        )
+    )
+    db.flush()
+
+
+def _get_email_lower(usuario) -> str:
+    email_lower = getattr(usuario, "user_email_lower", None)
+    if email_lower:
+        return email_lower
+    email = getattr(usuario, "email", "") or ""
+    return email.strip().lower()
+
+
+def historial_insert_params(db: Session, usuario) -> Tuple[str, dict, bool]:
+    """Determina el ``INSERT`` adecuado para ``historial`` y sus parámetros.
+
+    Devuelve una tupla ``(sql, params, has_id_column)`` donde ``has_id_column``
+    indica si la tabla posee una columna ``id`` para usar en ``RETURNING``.
+    """
+
+    columns = get_table_columns(db, "historial")
+    has_id = "id" in columns
+    email_lower = _get_email_lower(usuario)
+
+    if "user_id" in columns:
+        sql = "INSERT INTO historial (user_id, filename) VALUES (:uid, :filename)"
+        params = {"uid": getattr(usuario, "id", None), "filename": None}
+        return sql, params, has_id
+
+    if "user_email_lower" in columns:
+        sql = (
+            "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
+        )
+        params = {"email_lower": email_lower, "filename": None}
+        return sql, params, has_id
+
+    ensure_historial_user_email_lower(db)
+    sql = "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
+    params = {"email_lower": email_lower, "filename": None}
+    # Tras el ALTER TABLE asumimos que sigue existiendo la columna id si antes estaba
+    return sql, params, has_id
+
+
+__all__ = [
+    "get_table_columns",
+    "ensure_historial_user_email_lower",
+    "historial_insert_params",
+]

--- a/tests/test_exportar_csv.py
+++ b/tests/test_exportar_csv.py
@@ -1,0 +1,55 @@
+from backend.core import db_introspection
+
+
+class DummyUser:
+    def __init__(self, user_id=1, email="user@example.com"):
+        self.id = user_id
+        self.email = email
+
+
+def test_build_historial_insert_prefers_user_id(monkeypatch, db_session):
+    def fake_get_columns(db, table_name):
+        assert table_name == "historial"
+        return {"user_id", "filename"}
+
+    monkeypatch.setattr(db_introspection, "get_table_columns", fake_get_columns)
+
+    sql, params = db_introspection.build_historial_insert(db_session, DummyUser(user_id=42))
+
+    assert sql == "INSERT INTO historial (user_id, filename) VALUES (:uid, :filename)"
+    assert params == {"uid": 42}
+
+
+def test_build_historial_insert_uses_email_lower(monkeypatch, db_session):
+    def fake_get_columns(db, table_name):
+        assert table_name == "historial"
+        return {"user_email_lower", "filename"}
+
+    monkeypatch.setattr(db_introspection, "get_table_columns", fake_get_columns)
+
+    sql, params = db_introspection.build_historial_insert(
+        db_session, DummyUser(email="SomeOne@Example.com")
+    )
+
+    assert sql == "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
+    assert params == {"email_lower": "someone@example.com"}
+
+
+def test_build_historial_insert_creates_column(monkeypatch, db_session):
+    calls = {"ensure": 0}
+
+    def fake_get_columns(db, table_name):
+        assert table_name == "historial"
+        return set()
+
+    def fake_ensure(db):
+        calls["ensure"] += 1
+
+    monkeypatch.setattr(db_introspection, "get_table_columns", fake_get_columns)
+    monkeypatch.setattr(db_introspection, "ensure_historial_user_email_lower", fake_ensure)
+
+    sql, params = db_introspection.build_historial_insert(db_session, DummyUser())
+
+    assert calls["ensure"] == 1
+    assert sql == "INSERT INTO historial (user_email_lower, filename) VALUES (:email_lower, :filename)"
+    assert params == {"email_lower": "user@example.com"}

--- a/tests/test_historial_estado.py
+++ b/tests/test_historial_estado.py
@@ -10,6 +10,7 @@ def test_historial_and_estado_lead(client):
 
     r = client.post("/exportar_csv", json={"filename": "f.csv"}, headers=headers)
     assert r.status_code == 200
+    assert r.json() == {"ok": True, "filename": "f.csv"}
     r2 = client.get("/historial", headers=headers)
     assert r2.status_code == 200
     assert r2.json()["historial"][0]["filename"] == "f.csv"


### PR DESCRIPTION
## Summary
- add database introspection helpers to detect historial columns and ensure user_email_lower exists when needed
- update /exportar_csv to insert using the available historial column, with logging, error handling, and quota consumption after successful insert

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf126ab1c08323bfed819916db51cf