### PR TITLE
Align niche management endpoints with UI expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Otros endpoints relevantes: `/tarea_lead`, `/tareas_pendientes`, `/mi_memoria`, 
 - Esquema documentado en `AUDITORIA_TABLAS.md`; entidades clave: `usuarios`, `leads_extraidos`, `lead_estado`, `lead_tarea`, `lead_nota`, `user_usage_monthly`, `historial`.
 - Claves únicas y `CHECK` basados en `user_email_lower` para garantizar multi-tenant.
 - Migraciones gestionadas con Alembic (`alembic upgrade head`).
+- En Render, aplica las migraciones ejecutando `alembic upgrade head` desde un shell del servicio (Dashboard → Shell → `cd OpenSells && alembic upgrade head`) o añadiendo el comando como deploy hook previo al arranque.
 - Scripts de mantenimiento:
   - `scripts/migrar_sqlite_a_postgres.py`: migra datos principales desde instancias SQLite legadas.
   - `scripts/migrar_memoria_sqlite_a_postgres.py`: migra memorias/conversaciones del asistente.

--- a/backend/alembic/versions/20260715_fix_lead_info_estado_constraints.py
+++ b/backend/alembic/versions/20260715_fix_lead_info_estado_constraints.py
@@ -1,0 +1,402 @@
+"""Ensure lead info/estado uniqueness and schema"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect, text
+
+# revision identifiers, used by Alembic.
+revision = "20260715_fix_lead_info_estado_constraints"
+down_revision = "20260601_merge_parallel_heads"
+branch_labels = None
+depends_on = None
+
+
+def _ensure_lead_info_extra(bind):
+    inspector = inspect(bind)
+    tables = inspector.get_table_names()
+    if "lead_info_extra" not in tables:
+        op.create_table(
+            "lead_info_extra",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("user_email_lower", sa.Text, nullable=False),
+            sa.Column("dominio", sa.Text, nullable=False),
+            sa.Column("email", sa.Text, nullable=True),
+            sa.Column("telefono", sa.Text, nullable=True),
+            sa.Column("informacion", sa.Text, nullable=True),
+            sa.Column(
+                "timestamp",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.UniqueConstraint(
+                "user_email_lower",
+                "dominio",
+                name="uix_lead_info_extra_usuario_dominio",
+            ),
+        )
+        op.create_index(
+            "ix_lead_info_extra_user_email_lower",
+            "lead_info_extra",
+            ["user_email_lower"],
+        )
+        op.create_index(
+            "ix_lead_info_extra_dominio",
+            "lead_info_extra",
+            ["dominio"],
+        )
+        return
+
+    with bind.begin() as conn:
+        conn.execute(
+            text(
+                """
+                DELETE FROM lead_info_extra a
+                USING lead_info_extra b
+                WHERE a.ctid < b.ctid
+                  AND a.user_email_lower IS NOT DISTINCT FROM b.user_email_lower
+                  AND a.dominio IS NOT DISTINCT FROM b.dominio
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_info_extra
+                   SET user_email_lower = CONCAT('__legacy_user__:', id)
+                 WHERE user_email_lower IS NULL
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_info_extra
+                   SET dominio = CONCAT('__legacy_domain__:', id)
+                 WHERE dominio IS NULL
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_info_extra
+                   SET timestamp = NOW()
+                 WHERE timestamp IS NULL
+                """
+            )
+        )
+
+    inspector = inspect(bind)
+    columns = {col["name"]: col for col in inspector.get_columns("lead_info_extra")}
+    if "user_email_lower" not in columns:
+        op.add_column(
+            "lead_info_extra",
+            sa.Column("user_email_lower", sa.Text, nullable=False, server_default=""),
+        )
+        op.execute(
+            text(
+                "UPDATE lead_info_extra SET user_email_lower = CONCAT('__legacy_user__:', id) WHERE user_email_lower = ''"
+            )
+        )
+        op.alter_column(
+            "lead_info_extra",
+            "user_email_lower",
+            server_default=None,
+            existing_type=sa.Text(),
+            nullable=False,
+        )
+    else:
+        op.alter_column(
+            "lead_info_extra",
+            "user_email_lower",
+            existing_type=columns["user_email_lower"]["type"],
+            nullable=False,
+        )
+
+    if "dominio" not in columns:
+        op.add_column(
+            "lead_info_extra",
+            sa.Column("dominio", sa.Text, nullable=False, server_default="__legacy_domain__"),
+        )
+        op.execute(
+            text(
+                "UPDATE lead_info_extra SET dominio = CONCAT('__legacy_domain__:', id) WHERE dominio = '__legacy_domain__'"
+            )
+        )
+        op.alter_column(
+            "lead_info_extra",
+            "dominio",
+            existing_type=sa.Text(),
+            nullable=False,
+            server_default=None,
+        )
+    else:
+        op.alter_column(
+            "lead_info_extra",
+            "dominio",
+            existing_type=columns["dominio"]["type"],
+            nullable=False,
+        )
+
+    if "timestamp" not in columns:
+        op.add_column(
+            "lead_info_extra",
+            sa.Column(
+                "timestamp",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+    else:
+        op.alter_column(
+            "lead_info_extra",
+            "timestamp",
+            existing_type=columns["timestamp"]["type"],
+            nullable=False,
+            server_default=sa.func.now(),
+        )
+
+    inspector = inspect(bind)
+    uniques = {
+        uc["name"] for uc in inspector.get_unique_constraints("lead_info_extra")
+    }
+    if "uix_lead_info_extra_usuario_dominio" not in uniques:
+        op.create_unique_constraint(
+            "uix_lead_info_extra_usuario_dominio",
+            "lead_info_extra",
+            ["user_email_lower", "dominio"],
+        )
+
+    indexes = {ix["name"] for ix in inspector.get_indexes("lead_info_extra")}
+    if "ix_lead_info_extra_user_email_lower" not in indexes:
+        op.create_index(
+            "ix_lead_info_extra_user_email_lower",
+            "lead_info_extra",
+            ["user_email_lower"],
+        )
+    if "ix_lead_info_extra_dominio" not in indexes:
+        op.create_index(
+            "ix_lead_info_extra_dominio",
+            "lead_info_extra",
+            ["dominio"],
+        )
+
+
+def _ensure_lead_estado(bind):
+    inspector = inspect(bind)
+    tables = inspector.get_table_names()
+    if "lead_estado" not in tables:
+        op.create_table(
+            "lead_estado",
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("user_email_lower", sa.Text, nullable=False),
+            sa.Column("dominio", sa.Text, nullable=False),
+            sa.Column(
+                "estado",
+                sa.Text,
+                nullable=False,
+                server_default="pendiente",
+            ),
+            sa.Column(
+                "timestamp",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.UniqueConstraint(
+                "user_email_lower",
+                "dominio",
+                name="uix_lead_estado_usuario_dominio",
+            ),
+        )
+        op.create_index(
+            "ix_lead_estado_user_email_lower",
+            "lead_estado",
+            ["user_email_lower"],
+        )
+        op.create_index(
+            "ix_lead_estado_dominio",
+            "lead_estado",
+            ["dominio"],
+        )
+        return
+
+    with bind.begin() as conn:
+        conn.execute(
+            text(
+                """
+                DELETE FROM lead_estado a
+                USING lead_estado b
+                WHERE a.ctid < b.ctid
+                  AND a.user_email_lower IS NOT DISTINCT FROM b.user_email_lower
+                  AND a.dominio IS NOT DISTINCT FROM b.dominio
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_estado
+                   SET user_email_lower = CONCAT('__legacy_user__:', id)
+                 WHERE user_email_lower IS NULL
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_estado
+                   SET dominio = CONCAT('__legacy_domain__:', id)
+                 WHERE dominio IS NULL
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_estado
+                   SET estado = 'pendiente'
+                 WHERE estado IS NULL OR estado = ''
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                UPDATE lead_estado
+                   SET timestamp = NOW()
+                 WHERE timestamp IS NULL
+                """
+            )
+        )
+
+    inspector = inspect(bind)
+    columns = {col["name"]: col for col in inspector.get_columns("lead_estado")}
+    if "user_email_lower" not in columns:
+        op.add_column(
+            "lead_estado",
+            sa.Column("user_email_lower", sa.Text, nullable=False, server_default=""),
+        )
+        op.execute(
+            text(
+                "UPDATE lead_estado SET user_email_lower = CONCAT('__legacy_user__:', id) WHERE user_email_lower = ''"
+            )
+        )
+        op.alter_column(
+            "lead_estado",
+            "user_email_lower",
+            existing_type=sa.Text(),
+            nullable=False,
+            server_default=None,
+        )
+    else:
+        op.alter_column(
+            "lead_estado",
+            "user_email_lower",
+            existing_type=columns["user_email_lower"]["type"],
+            nullable=False,
+        )
+
+    if "dominio" not in columns:
+        op.add_column(
+            "lead_estado",
+            sa.Column("dominio", sa.Text, nullable=False, server_default="__legacy_domain__"),
+        )
+        op.execute(
+            text(
+                "UPDATE lead_estado SET dominio = CONCAT('__legacy_domain__:', id) WHERE dominio = '__legacy_domain__'"
+            )
+        )
+        op.alter_column(
+            "lead_estado",
+            "dominio",
+            existing_type=sa.Text(),
+            nullable=False,
+            server_default=None,
+        )
+    else:
+        op.alter_column(
+            "lead_estado",
+            "dominio",
+            existing_type=columns["dominio"]["type"],
+            nullable=False,
+        )
+
+    if "estado" not in columns:
+        op.add_column(
+            "lead_estado",
+            sa.Column("estado", sa.Text, nullable=False, server_default="pendiente"),
+        )
+    else:
+        op.alter_column(
+            "lead_estado",
+            "estado",
+            existing_type=columns["estado"]["type"],
+            nullable=False,
+            server_default="pendiente",
+        )
+
+    if "timestamp" not in columns:
+        op.add_column(
+            "lead_estado",
+            sa.Column(
+                "timestamp",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
+    else:
+        op.alter_column(
+            "lead_estado",
+            "timestamp",
+            existing_type=columns["timestamp"]["type"],
+            nullable=False,
+            server_default=sa.func.now(),
+        )
+
+    inspector = inspect(bind)
+    uniques = {uc["name"] for uc in inspector.get_unique_constraints("lead_estado")}
+    if "uix_lead_estado_usuario_dominio" not in uniques:
+        op.create_unique_constraint(
+            "uix_lead_estado_usuario_dominio",
+            "lead_estado",
+            ["user_email_lower", "dominio"],
+        )
+
+    indexes = {ix["name"] for ix in inspector.get_indexes("lead_estado")}
+    if "ix_lead_estado_user_email_lower" not in indexes:
+        op.create_index(
+            "ix_lead_estado_user_email_lower",
+            "lead_estado",
+            ["user_email_lower"],
+        )
+    if "ix_lead_estado_dominio" not in indexes:
+        op.create_index(
+            "ix_lead_estado_dominio",
+            "lead_estado",
+            ["dominio"],
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _ensure_lead_info_extra(bind)
+    _ensure_lead_estado(bind)
+
+
+def downgrade() -> None:
+    # Revert indexes and constraints created in upgrade.
+    op.drop_index("ix_lead_estado_dominio", table_name="lead_estado")
+    op.drop_index("ix_lead_estado_user_email_lower", table_name="lead_estado")
+    with op.batch_alter_table("lead_estado") as batch:
+        batch.drop_constraint("uix_lead_estado_usuario_dominio", type_="unique")
+
+    op.drop_index("ix_lead_info_extra_dominio", table_name="lead_info_extra")
+    op.drop_index(
+        "ix_lead_info_extra_user_email_lower", table_name="lead_info_extra"
+    )
+    with op.batch_alter_table("lead_info_extra") as batch:
+        batch.drop_constraint("uix_lead_info_extra_usuario_dominio", type_="unique")

--- a/backend/create_tables.py
+++ b/backend/create_tables.py
@@ -6,6 +6,7 @@ from backend.models import (
     LeadNota,
     LeadInfoExtra,
     LeadExtraido,
+    LeadEstado,
     UsuarioMemoria,
 )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,7 +24,7 @@ from backend.models import LeadTarea
 import httpx
 
 # --- Local / project ---
-from backend.database import engine, SessionLocal, DATABASE_URL, get_db
+from backend.database import Base, engine, SessionLocal, DATABASE_URL, get_db
 from backend.models import (
     Usuario,
     HistorialExport,
@@ -81,6 +81,9 @@ if os.getenv("ENV") == "dev":
     from backend.routers import debug
 
     app.include_router(debug.router)
+
+    # Asegura que las tablas existan en entornos locales de desarrollo
+    Base.metadata.create_all(bind=engine)
 
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ import csv
 import io
 import os
 import logging
+import unicodedata
 import re
 from urllib.parse import urlparse
 
@@ -28,6 +29,7 @@ from backend.models import (
     Usuario,
     HistorialExport,
     LeadEstado,
+    LeadInfoExtra,
     LeadExtraido,
     LeadTarea,
     UsuarioMemoria,
@@ -96,6 +98,15 @@ def normalizar_dominio(value: str) -> str:
     v = v.lower()
     v = v.split("/")[0].strip()
     return v
+
+
+def normalizar_nicho(value: str) -> str:
+    if not value:
+        return ""
+    v = unicodedata.normalize("NFKD", value.strip().lower())
+    v = v.encode("ascii", "ignore").decode("ascii")
+    v = re.sub(r"[^a-z0-9]+", "_", v)
+    return v.strip("_")
 
 
 # --- Búsqueda y scraping ---
@@ -572,6 +583,123 @@ class LeadItem(BaseModel):
     nicho_original: str
 
 
+class InfoExtraPayload(BaseModel):
+    dominio: str
+    email: Optional[str] = None
+    telefono: Optional[str] = None
+    informacion: Optional[str] = None
+
+    @validator("dominio", pre=True)
+    def _strip_dominio(cls, value: Any):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @validator("email", "telefono", "informacion", pre=True)
+    def _empty_to_none(cls, value: Any):
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
+
+
+class LeadManualPayload(BaseModel):
+    dominio: str
+    nicho: str
+    email: Optional[str] = None
+    telefono: Optional[str] = None
+    nombre: Optional[str] = None
+
+    @validator("dominio", "nicho", pre=True)
+    def _strip_required(cls, value: Any):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @validator("email", "telefono", "nombre", pre=True)
+    def _strip_optional(cls, value: Any):
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
+
+
+class MoverLeadPayload(BaseModel):
+    dominio: str
+    origen: str
+    destino: str
+
+    @validator("dominio", "origen", "destino", pre=True)
+    def _strip_values(cls, value: Any):
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+
+class EstadoContactoUpdatePayload(BaseModel):
+    estado_contacto: Literal[
+        "pendiente",
+        "en_proceso",
+        "contactado",
+        "cerrado",
+        "fallido",
+    ]
+
+
+ESTADOS_CONTACTO_VALIDOS = {
+    "pendiente",
+    "en_proceso",
+    "contactado",
+    "cerrado",
+    "fallido",
+}
+
+
+_INFO_UNSET = object()
+
+
+def _upsert_info_extra(
+    db: Session,
+    *,
+    user_email_lower: str,
+    dominio: str,
+    email: Optional[str] | object = _INFO_UNSET,
+    telefono: Optional[str] | object = _INFO_UNSET,
+    informacion: Optional[str] | object = _INFO_UNSET,
+) -> None:
+    tbl = LeadInfoExtra.__table__
+    insert_values: dict[str, Any] = {
+        "user_email_lower": user_email_lower,
+        "dominio": dominio,
+    }
+    if email is not _INFO_UNSET:
+        insert_values["email"] = email
+    if telefono is not _INFO_UNSET:
+        insert_values["telefono"] = telefono
+    if informacion is not _INFO_UNSET:
+        insert_values["informacion"] = informacion
+
+    stmt = pg_insert(tbl).values(insert_values)
+
+    update_values: dict[Any, Any] = {}
+    if email is not _INFO_UNSET:
+        update_values[tbl.c.email] = email
+    if telefono is not _INFO_UNSET:
+        update_values[tbl.c.telefono] = telefono
+    if informacion is not _INFO_UNSET:
+        update_values[tbl.c.informacion] = informacion
+
+    if update_values:
+        update_values[tbl.c.timestamp] = func.now()
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[tbl.c.user_email_lower, tbl.c.dominio],
+            set_=update_values,
+        )
+    else:
+        stmt = stmt.on_conflict_do_nothing()
+
+    db.execute(stmt)
+
 @app.post("/extraer_multiples")
 def extraer_multiples(payload: ExtraerMultiplesPayload, usuario=Depends(get_current_user), db: Session = Depends(get_db)):
     """
@@ -960,15 +1088,262 @@ def leads_por_nicho(
     return {"items": items, "limit": limit, "offset": offset, "count": len(items)}
 
 
+
+
+@app.get("/info_extra")
+def obtener_info_extra(
+    dominio: str = Query(..., description="Dominio del lead"),
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dominio_norm = normalizar_dominio(dominio)
+    if not dominio_norm:
+        raise HTTPException(status_code=400, detail="Falta 'dominio'")
+
+    row = (
+        db.query(LeadInfoExtra)
+        .filter(
+            LeadInfoExtra.user_email_lower == usuario.email_lower,
+            LeadInfoExtra.dominio == dominio_norm,
+        )
+        .first()
+    )
+    if not row:
+        return {"email": "", "telefono": "", "informacion": ""}
+
+    return {
+        "email": row.email or "",
+        "telefono": row.telefono or "",
+        "informacion": row.informacion or "",
+    }
+
+
+@app.post("/guardar_info_extra")
+def guardar_info_extra(
+    payload: InfoExtraPayload,
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dominio_norm = normalizar_dominio(payload.dominio)
+    if not dominio_norm:
+        raise HTTPException(status_code=400, detail="Falta 'dominio'")
+
+    _upsert_info_extra(
+        db,
+        user_email_lower=usuario.email_lower,
+        dominio=dominio_norm,
+        email=payload.email,
+        telefono=payload.telefono,
+        informacion=payload.informacion,
+    )
+    db.commit()
+    return {"ok": True}
+
+
+@app.post("/añadir_lead_manual")
+def añadir_lead_manual(
+    payload: LeadManualPayload,
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dominio_norm = normalizar_dominio(payload.dominio)
+    if not dominio_norm:
+        raise HTTPException(status_code=400, detail="Falta 'dominio'")
+
+    nicho_original = payload.nicho or ""
+    nicho_norm = normalizar_nicho(nicho_original)
+    if not nicho_norm:
+        raise HTTPException(status_code=400, detail="Falta 'nicho'")
+
+    url_value = f"https://{dominio_norm}"
+    tbl = LeadExtraido.__table__
+    stmt = (
+        pg_insert(tbl)
+        .values(
+            user_email=usuario.email,
+            user_email_lower=usuario.email_lower,
+            dominio=dominio_norm,
+            url=url_value,
+            estado_contacto="pendiente",
+            nicho=nicho_norm,
+            nicho_original=nicho_original or nicho_norm,
+            timestamp=func.now(),
+        )
+        .on_conflict_do_nothing()
+        .returning(tbl.c.id)
+    )
+    result = db.execute(stmt)
+    created_id = result.scalar()
+
+    if payload.email or payload.telefono:
+        _upsert_info_extra(
+            db,
+            user_email_lower=usuario.email_lower,
+            dominio=dominio_norm,
+            email=payload.email,
+            telefono=payload.telefono,
+        )
+
+    db.commit()
+    return {"ok": True, "created": bool(created_id)}
+
+
+@app.delete("/eliminar_lead")
+def eliminar_lead(
+    dominio: str = Query(..., description="Dominio a eliminar"),
+    nicho: str | None = Query(None),
+    solo_de_este_nicho: bool = Query(False),
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dominio_norm = normalizar_dominio(dominio)
+    if not dominio_norm:
+        raise HTTPException(status_code=400, detail="Falta 'dominio'")
+
+    base_query = db.query(LeadExtraido).filter(
+        LeadExtraido.user_email_lower == usuario.email_lower,
+        LeadExtraido.dominio == dominio_norm,
+    )
+
+    if solo_de_este_nicho:
+        if not nicho:
+            raise HTTPException(status_code=400, detail="Falta 'nicho'")
+        nicho_norm = normalizar_nicho(nicho)
+        row = base_query.filter(LeadExtraido.nicho == nicho_norm).first()
+        if not row:
+            raise HTTPException(status_code=404, detail="Lead no encontrado en ese nicho")
+        db.delete(row)
+        db.commit()
+        return {"ok": True}
+
+    deleted = base_query.delete(synchronize_session=False)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Lead no encontrado")
+
+    db.commit()
+    return {"ok": True}
+
+
+@app.post("/mover_lead")
+def mover_lead(
+    payload: MoverLeadPayload,
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    dominio_norm = normalizar_dominio(payload.dominio)
+    if not dominio_norm:
+        raise HTTPException(status_code=400, detail="Falta 'dominio'")
+
+    destino_norm = normalizar_nicho(payload.destino)
+    if not destino_norm:
+        raise HTTPException(status_code=400, detail="Falta 'destino'")
+
+    lead = (
+        db.query(LeadExtraido)
+        .filter(
+            LeadExtraido.user_email_lower == usuario.email_lower,
+            LeadExtraido.dominio == dominio_norm,
+        )
+        .first()
+    )
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead no encontrado")
+
+    origen_norm = normalizar_nicho(payload.origen)
+    if origen_norm and lead.nicho != origen_norm:
+        raise HTTPException(status_code=404, detail="Lead no encontrado en el nicho de origen")
+
+    lead.nicho = destino_norm
+    lead.nicho_original = (payload.destino or "").strip() or lead.nicho_original
+    db.commit()
+    return {"ok": True}
+
+
+@app.delete("/eliminar_nicho")
+def eliminar_nicho(
+    nicho: str = Query(..., description="Nicho a eliminar"),
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    nicho_norm = normalizar_nicho(nicho)
+    if not nicho_norm:
+        raise HTTPException(status_code=400, detail="Falta 'nicho'")
+
+    deleted = (
+        db.query(LeadExtraido)
+        .filter(
+            LeadExtraido.user_email_lower == usuario.email_lower,
+            LeadExtraido.nicho == nicho_norm,
+        )
+        .delete(synchronize_session=False)
+    )
+    db.commit()
+    return {"ok": True, "deleted": deleted}
+
+
+@app.patch("/leads/{lead_id}/estado_contacto")
+def actualizar_estado_contacto(
+    lead_id: int,
+    payload: EstadoContactoUpdatePayload,
+    usuario=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    lead = (
+        db.query(LeadExtraido)
+        .filter(
+            LeadExtraido.user_email_lower == usuario.email_lower,
+            LeadExtraido.id == lead_id,
+        )
+        .first()
+    )
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead no encontrado")
+
+    lead.estado_contacto = payload.estado_contacto
+    estado_tbl = LeadEstado.__table__
+    stmt = (
+        pg_insert(estado_tbl)
+        .values(
+            user_email_lower=usuario.email_lower,
+            dominio=lead.dominio,
+            estado=payload.estado_contacto,
+            timestamp=func.now(),
+        )
+        .on_conflict_do_update(
+            index_elements=[estado_tbl.c.user_email_lower, estado_tbl.c.dominio],
+            set_={
+                estado_tbl.c.estado: payload.estado_contacto,
+                estado_tbl.c.timestamp: func.now(),
+            },
+        )
+    )
+    db.execute(stmt)
+    db.commit()
+    return {"ok": True}
+
 @app.get("/exportar_leads_nicho")
 def exportar_leads_nicho(
     nicho: str = Query(..., description="Nombre del nicho a exportar"),
+    estado_contacto: Optional[str] = Query(
+        None, description="Filtrar por estado de contacto"
+    ),
     usuario=Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
     nicho = (nicho or "").strip()
     if not nicho:
         raise HTTPException(status_code=400, detail="Falta 'nicho'")
+
+    estado_contacto = (estado_contacto or "").strip()
+    if estado_contacto and estado_contacto not in ESTADOS_CONTACTO_VALIDOS:
+        raise HTTPException(status_code=400, detail="Estado de contacto no válido")
+
+    filters = [
+        LeadExtraido.user_email_lower == usuario.email_lower,
+        LeadExtraido.nicho == nicho,
+    ]
+    if estado_contacto:
+        filters.append(LeadExtraido.estado_contacto == estado_contacto)
 
     stmt = (
         select(
@@ -979,10 +1354,7 @@ def exportar_leads_nicho(
             LeadExtraido.nicho,
             LeadExtraido.nicho_original,
         )
-        .where(
-            LeadExtraido.user_email_lower == usuario.email_lower,
-            LeadExtraido.nicho == nicho,
-        )
+        .where(*filters)
         .order_by(LeadExtraido.timestamp.desc())
     )
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -152,18 +152,20 @@ class LeadInfoExtra(Base):
     __tablename__ = "lead_info_extra"
 
     id = Column(Integer, primary_key=True)
-    dominio = Column(String, nullable=False)
+    user_email_lower = Column(String, nullable=False, index=True)
+    dominio = Column(String, nullable=False, index=True)
     email = Column(String)
     telefono = Column(String)
     informacion = Column(Text)
-    user_email = Column(String)
-    user_email_lower = Column(String, index=True, nullable=False)
-    timestamp = Column(DateTime(timezone=True), server_default=func.now())
+    timestamp = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 
-    @validates("user_email")
-    def _set_lower(self, key, value):
-        self.user_email_lower = (value or "").strip().lower()
-        return (value or "").strip()
+    __table_args__ = (
+        UniqueConstraint(
+            "user_email_lower",
+            "dominio",
+            name="uix_lead_info_extra_usuario_dominio",
+        ),
+    )
 
 class LeadExtraido(Base):
     __tablename__ = "leads_extraidos"

--- a/backend/models.py
+++ b/backend/models.py
@@ -154,10 +154,16 @@ class LeadInfoExtra(Base):
     id = Column(Integer, primary_key=True)
     user_email_lower = Column(String, nullable=False, index=True)
     dominio = Column(String, nullable=False, index=True)
-    email = Column(String)
-    telefono = Column(String)
-    informacion = Column(Text)
-    timestamp = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    email = Column(String, nullable=True)
+    telefono = Column(String, nullable=True)
+    informacion = Column(Text, nullable=True)
+    timestamp = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+    )
 
     __table_args__ = (
         UniqueConstraint(
@@ -223,10 +229,20 @@ class LeadEstado(Base):
 
     id = Column(Integer, primary_key=True)
     user_email_lower = Column(String, nullable=False, index=True)
-    url = Column(String)
-    dominio = Column(String)
-    estado = Column(String, nullable=False, server_default="pendiente")
-    timestamp = Column(DateTime(timezone=True), server_default=func.now())
+    dominio = Column(String, nullable=False, index=True)
+    estado = Column(
+        String,
+        nullable=False,
+        server_default="pendiente",
+        default="pendiente",
+    )
+    timestamp = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+        default=lambda: datetime.now(timezone.utc),
+    )
 
     __table_args__ = (
         UniqueConstraint(

--- a/streamlit_app/pages/3_Mis_Nichos.py
+++ b/streamlit_app/pages/3_Mis_Nichos.py
@@ -180,16 +180,6 @@ def render_estado_badge(estado: str) -> str:
     return '<span class="badge badge-ok">Contactado</span>'
 
 
-def _cambiar_estado(key: str, dominio: str):
-    nuevo = st.session_state.get(key)
-    cached_post(
-        "leads/estado_contacto",
-        token,
-        payload={"dominio": dominio, "estado_contacto": nuevo},
-    )
-    st.session_state["forzar_recarga"] += 1
-    st.rerun()
-
 # ── Forzar Recarga Caché ─────────────────────────────
 if "forzar_recarga" not in st.session_state:
     st.session_state["forzar_recarga"] = 0

--- a/streamlit_app/utils/http_client.py
+++ b/streamlit_app/utils/http_client.py
@@ -125,6 +125,21 @@ def post(path: str, **kwargs):
     return r
 
 
+def patch(path: str, **kwargs):
+    custom_headers = kwargs.pop("headers", None)
+    timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT)
+    url = _full_url(path)
+    try:
+        r = _session.patch(url, headers=_merge_headers(custom_headers), timeout=timeout, **kwargs)
+    except (requests.ConnectionError, requests.ChunkedEncodingError):
+        _reset_session()
+        hdrs = _merge_headers({**(custom_headers or {}), "Connection": "close"})
+        r = _session.patch(url, headers=hdrs, timeout=timeout, **kwargs)
+    if r.status_code == 401:
+        return {"_error": "unauthorized", "_status": 401}
+    return r
+
+
 def put(path: str, **kwargs):
     custom_headers = kwargs.pop("headers", None)
     timeout = kwargs.pop("timeout", DEFAULT_TIMEOUT)

--- a/tests/test_lead_info_estado_endpoints.py
+++ b/tests/test_lead_info_estado_endpoints.py
@@ -1,0 +1,149 @@
+from sqlalchemy import text
+
+from tests.helpers import auth
+
+
+def test_guardar_info_extra_upsert(client, db_session):
+    headers = auth(client, "notes@example.com")
+
+    payload = {
+        "dominio": "Mi-Dominio.com",
+        "email": "contacto@mi-dominio.com",
+        "telefono": "+34 600 000 000",
+        "informacion": "Nota inicial",
+    }
+    resp = client.post("/guardar_info_extra", json=payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    consulta = client.get(
+        "/info_extra", params={"dominio": "mi-dominio.com"}, headers=headers
+    )
+    assert consulta.status_code == 200
+    data = consulta.json()
+    assert data["informacion"] == "Nota inicial"
+    assert data["email"] == "contacto@mi-dominio.com"
+    assert data["telefono"] == "+34 600 000 000"
+
+    # Actualización parcial para validar el ON CONFLICT
+    resp = client.post(
+        "/guardar_info_extra",
+        json={"dominio": "mi-dominio.com", "informacion": "Nota actualizada"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    again = client.get(
+        "/info_extra", params={"dominio": "MI-DOMINIO.COM"}, headers=headers
+    )
+    assert again.status_code == 200
+    data = again.json()
+    assert data["informacion"] == "Nota actualizada"
+    assert data["email"] == "contacto@mi-dominio.com"
+    assert data["telefono"] == "+34 600 000 000"
+
+    count = db_session.execute(
+        text(
+            """
+            SELECT COUNT(*)
+              FROM lead_info_extra
+             WHERE user_email_lower = :user
+               AND dominio = :dominio
+            """
+        ),
+        {"user": "notes@example.com", "dominio": "mi-dominio.com"},
+    ).scalar_one()
+    assert count == 1
+
+
+def test_patch_estado_contacto_creates_single_row(client, db_session):
+    headers = auth(client, "estado@example.com")
+
+    alta = client.post(
+        "/añadir_lead_manual",
+        json={
+            "dominio": "estado.com",
+            "nicho": "Consultoría",
+            "email": "info@estado.com",
+        },
+        headers=headers,
+    )
+    assert alta.status_code == 200, alta.text
+
+    lead_id = db_session.execute(
+        text(
+            """
+            SELECT id
+              FROM leads_extraidos
+             WHERE user_email_lower = :user
+               AND dominio = :dominio
+            """
+        ),
+        {"user": "estado@example.com", "dominio": "estado.com"},
+    ).scalar_one()
+
+    cambio = client.patch(
+        f"/leads/{lead_id}/estado_contacto",
+        json={"estado_contacto": "contactado"},
+        headers=headers,
+    )
+    assert cambio.status_code == 200, cambio.text
+    assert cambio.json()["ok"] is True
+
+    post = db_session.execute(
+        text(
+            """
+            SELECT estado_contacto
+              FROM leads_extraidos
+             WHERE id = :lead_id
+            """
+        ),
+        {"lead_id": lead_id},
+    ).scalar_one()
+    assert post == "contactado"
+
+    estado_fila = db_session.execute(
+        text(
+            """
+            SELECT estado
+              FROM lead_estado
+             WHERE user_email_lower = :user
+               AND dominio = :dominio
+            """
+        ),
+        {"user": "estado@example.com", "dominio": "estado.com"},
+    ).scalar_one()
+    assert estado_fila == "contactado"
+
+    # Segundo cambio: debe actualizar sin crear duplicados
+    cambio2 = client.patch(
+        f"/leads/{lead_id}/estado_contacto",
+        json={"estado_contacto": "cerrado"},
+        headers=headers,
+    )
+    assert cambio2.status_code == 200, cambio2.text
+
+    estado_final = db_session.execute(
+        text(
+            """
+            SELECT estado
+              FROM lead_estado
+             WHERE user_email_lower = :user
+               AND dominio = :dominio
+            """
+        ),
+        {"user": "estado@example.com", "dominio": "estado.com"},
+    ).scalar_one()
+    assert estado_final == "cerrado"
+
+    total_rows = db_session.execute(
+        text(
+            """
+            SELECT COUNT(*)
+              FROM lead_estado
+             WHERE user_email_lower = :user
+               AND dominio = :dominio
+            """
+        ),
+        {"user": "estado@example.com", "dominio": "estado.com"},
+    ).scalar_one()
+    assert total_rows == 1


### PR DESCRIPTION
## Summary
- add a backend niche normalizer plus CRUD endpoints for lead info, manual adds, moving and deleting nichos, and patch-based estado updates with optional export filters
- tighten LeadInfoExtra schema with a unique constraint per user/domain and helper to upsert selective columns
- expose HTTP PATCH from the Streamlit client and switch the Mis Nichos page to the new estado API while dropping the legacy helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d19e760cd48323bb6822b369687cd9