### PR TITLE
Add persistent JWT auth handling for Streamlit frontend

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -16,7 +16,7 @@ import streamlit as st
 
 from components.ui import render_whatsapp_fab
 
-from streamlit_app.utils.auth_utils import ensure_session_or_redirect, clear_session
+from streamlit_app.auth_client import ensure_authenticated, clear_token
 from streamlit_app.utils.cookies_utils import init_cookie_manager_mount
 from streamlit_app.utils.nav import go, HOME_PAGE
 
@@ -33,19 +33,18 @@ if DATABASE_URL:
 
 st.set_page_config(page_title="OpenSells — tu motor de prospección y leads", page_icon="🧩")
 
-ensure_session_or_redirect()
-token = st.session_state.get("auth_token")
-user = st.session_state.get("user")
-if not user:
-    import streamlit_app.utils.http_client as http_client
-    resp_user = http_client.get("/me")
-    if resp_user is not None and resp_user.status_code == 200:
-        user = resp_user.json()
-        st.session_state["user"] = user
+if not ensure_authenticated():
+    go(HOME_PAGE)
+    st.stop()
+
+user = st.session_state.get("user") or st.session_state.get("me")
+if user:
+    st.session_state["user"] = user
 
 if st.sidebar.button("Cerrar sesión"):
-    clear_session(preserve_logout_flag=True)
+    clear_token()
     go(HOME_PAGE)
+    st.experimental_rerun()
 
 st.title("OpenSells — tu motor de prospección y leads")
 st.markdown(

--- a/streamlit_app/auth_client.py
+++ b/streamlit_app/auth_client.py
@@ -1,0 +1,87 @@
+import os
+from typing import Optional
+
+import requests
+import streamlit as st
+from streamlit_js_eval import streamlit_js_eval
+
+BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
+LS_KEY = "wrapper_jwt"
+
+
+def _ls_get_token() -> Optional[str]:
+    token = streamlit_js_eval(js_expressions="localStorage.getItem('%s')" % LS_KEY, key="get_jwt")
+    if token and isinstance(token, str):
+        token = token.strip()
+        if token:
+            return token
+    return None
+
+
+def _ls_set_token(token: str) -> None:
+    safe = token.replace("\\", "\\\\").replace("'", "\\'")
+    streamlit_js_eval(js_expressions=f"localStorage.setItem('{LS_KEY}', '{safe}')", key="set_jwt")
+
+
+def _ls_clear_token() -> None:
+    streamlit_js_eval(js_expressions=f"localStorage.removeItem('{LS_KEY}')", key="del_jwt")
+
+
+def save_token(token: str) -> None:
+    st.session_state["jwt"] = token
+    st.session_state["auth_token"] = token
+    _ls_set_token(token)
+
+
+def clear_token() -> None:
+    st.session_state.pop("jwt", None)
+    st.session_state.pop("auth_token", None)
+    st.session_state.pop("me", None)
+    st.session_state.pop("auth_email", None)
+    _ls_clear_token()
+
+
+def current_token() -> Optional[str]:
+    token = st.session_state.get("jwt") or st.session_state.get("auth_token")
+    if token:
+        st.session_state["jwt"] = token
+        st.session_state["auth_token"] = token
+        return token
+    token = _ls_get_token()
+    if token:
+        st.session_state["jwt"] = token
+        st.session_state["auth_token"] = token
+        return token
+    return None
+
+
+def fetch_me(token: str) -> Optional[dict]:
+    try:
+        r = requests.get(
+            f"{BACKEND_URL}/me",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10,
+        )
+        if r.status_code == 200:
+            return r.json()
+    except Exception:
+        pass
+    return None
+
+
+def ensure_authenticated() -> bool:
+    token = current_token()
+    if not token:
+        return False
+    me = fetch_me(token)
+    if not me:
+        clear_token()
+        return False
+    st.session_state["me"] = me
+    st.session_state["user"] = me
+    return True
+
+
+def auth_headers() -> dict:
+    token = current_token()
+    return {"Authorization": f"Bearer {token}"} if token else {}

--- a/streamlit_app/pages/1_Busqueda.py
+++ b/streamlit_app/pages/1_Busqueda.py
@@ -7,20 +7,16 @@ from dotenv import load_dotenv
 from urllib.parse import urlparse
 from json import JSONDecodeError
 
+from streamlit_app.auth_client import ensure_authenticated, current_token, auth_headers as auth_client_headers
 import streamlit_app.utils.http_client as http_client
 
 from streamlit_app.cache_utils import (
     cached_get,
     get_openai_client,
-    auth_headers,
     limpiar_cache,
 )
 from streamlit_app.plan_utils import subscription_cta
-from streamlit_app.utils.auth_session import (
-    is_authenticated,
-    remember_current_page,
-    get_auth_token,
-)
+from streamlit_app.utils.auth_session import remember_current_page
 from streamlit_app.utils.logout_button import logout_button
 from streamlit_app.ui.account_helpers import fetch_account_overview, get_plan_name
 from components.ui import render_whatsapp_fab
@@ -31,14 +27,14 @@ st.set_page_config(page_title="Buscar Leads", page_icon="🔎", layout="centered
 
 PAGE_NAME = "Leads"
 remember_current_page(PAGE_NAME)
-if not is_authenticated():
+if not ensure_authenticated():
     st.title(PAGE_NAME)
-    st.info("Inicia sesión en la página Home para continuar.")
+    st.warning("Sesión expirada. Vuelve a iniciar sesión.")
     st.stop()
 
 BACKEND_URL = http_client.BASE_URL
 
-token = get_auth_token()
+token = current_token()
 me, usage, quotas, _ = fetch_account_overview(token) if token else ({}, {}, {}, {})
 user = me
 st.session_state["user"] = user
@@ -142,7 +138,7 @@ for flag, valor in {
 }.items():
     st.session_state.setdefault(flag, valor)
 
-headers = auth_headers(token)
+headers = auth_client_headers()
 
 if st.session_state.get("limit_error_detail"):
     mostrar_banner_limite(st.session_state.get("limit_error_detail"))

--- a/streamlit_app/pages/5_Exportaciones.py
+++ b/streamlit_app/pages/5_Exportaciones.py
@@ -1,7 +1,8 @@
 import streamlit as st
 
+from streamlit_app.auth_client import ensure_authenticated, current_token
 import streamlit_app.utils.http_client as http_client
-from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token
+from streamlit_app.utils.auth_session import remember_current_page
 from streamlit_app.utils.logout_button import logout_button
 from components.ui import render_whatsapp_fab
 
@@ -9,21 +10,15 @@ st.set_page_config(page_title="Exportaciones", page_icon="📤")
 
 PAGE_NAME = "Exportaciones"
 remember_current_page(PAGE_NAME)
-if not is_authenticated():
+if not ensure_authenticated():
     st.title(PAGE_NAME)
-    st.info("Inicia sesión en la página Home para continuar.")
+    st.warning("Sesión expirada. Vuelve a iniciar sesión.")
     st.stop()
 
-token = get_auth_token()
-user = st.session_state.get("user")
-if token and not user:
-    resp_user = http_client.get("/me")
-    if isinstance(resp_user, dict) and resp_user.get("_error") == "unauthorized":
-        st.warning("Sesión expirada. Vuelve a iniciar sesión.")
-        st.stop()
-    if getattr(resp_user, "status_code", None) == 200:
-        user = resp_user.json()
-        st.session_state["user"] = user
+token = current_token()
+user = st.session_state.get("user") or st.session_state.get("me")
+if user:
+    st.session_state["user"] = user
 
 with st.sidebar:
     logout_button()

--- a/streamlit_app/pages/6_Emails.py
+++ b/streamlit_app/pages/6_Emails.py
@@ -1,8 +1,9 @@
 import streamlit as st
 
+from streamlit_app.auth_client import ensure_authenticated, current_token
 from streamlit_app.plan_utils import resolve_user_plan, tiene_suscripcion_activa, subscription_cta
 import streamlit_app.utils.http_client as http_client
-from streamlit_app.utils.auth_session import is_authenticated, remember_current_page, get_auth_token
+from streamlit_app.utils.auth_session import remember_current_page
 from streamlit_app.utils.logout_button import logout_button
 from components.ui import render_whatsapp_fab
 
@@ -10,21 +11,15 @@ st.set_page_config(page_title="Emails", page_icon="✉️")
 
 PAGE_NAME = "Emails"
 remember_current_page(PAGE_NAME)
-if not is_authenticated():
+if not ensure_authenticated():
     st.title(PAGE_NAME)
-    st.info("Inicia sesión en la página Home para continuar.")
+    st.warning("Sesión expirada. Vuelve a iniciar sesión.")
     st.stop()
 
-token = get_auth_token()
-user = st.session_state.get("user")
-if token and not user:
-    resp_user = http_client.get("/me")
-    if isinstance(resp_user, dict) and resp_user.get("_error") == "unauthorized":
-        st.warning("Sesión expirada. Vuelve a iniciar sesión.")
-        st.stop()
-    if getattr(resp_user, "status_code", None) == 200:
-        user = resp_user.json()
-        st.session_state["user"] = user
+token = current_token()
+user = st.session_state.get("user") or st.session_state.get("me")
+if user:
+    st.session_state["user"] = user
 
 with st.sidebar:
     logout_button()

--- a/streamlit_app/utils/auth_session.py
+++ b/streamlit_app/utils/auth_session.py
@@ -1,103 +1,41 @@
-import base64
+"""Backwards-compatible helpers around the new auth_client utilities."""
+
+from __future__ import annotations
+
 import streamlit as st
 
-# 👇 🔵 NEW: import conditional for extra_streamlit_components
-try:
-    import extra_streamlit_components as stx
-except Exception:  # pragma: no cover
-    stx = None
+from streamlit_app.auth_client import (
+    clear_token as _clear_token,
+    current_token as _current_token,
+    ensure_authenticated as _ensure_authenticated,
+    save_token as _save_token,
+)
 
-TOKEN_KEY = "auth_token"
-_LS_KEY = "wrapper_auth_b64"
-
-
-def _encode(v: str) -> str:
-    return base64.urlsafe_b64encode(v.encode()).decode()
-
-
-def _decode(v: str) -> str:
-    return base64.urlsafe_b64decode(v.encode()).decode()
-
-
-def _localstorage_set(b64: str | None):
-    if stx is None:
-        return
-    try:
-        stx.LocalStorage().set_item(_LS_KEY, b64 if b64 is not None else "")
-    except Exception:
-        pass
-
-
-def _localstorage_get() -> str | None:
-    if stx is None:
-        return None
-    try:
-        val = stx.LocalStorage().get_item(_LS_KEY)
-        if not val:
-            return None
-        return val
-    except Exception:
-        return None
+TOKEN_KEY = "jwt"
 
 
 def set_auth_token(token: str):
-    # State in memory
-    st.session_state[TOKEN_KEY] = token
-    # URL
-    qp = st.query_params
-    qp["t"] = _encode(token)
-    st.query_params = qp
-    # 👇 NEW: mirror in LocalStorage
-    _localstorage_set(_encode(token))
+    """Persist the token using the shared auth_client helpers."""
+    if not token:
+        return
+    _save_token(token)
 
 
 def clear_auth_token():
-    # Memory
-    if TOKEN_KEY in st.session_state:
-        del st.session_state[TOKEN_KEY]
-    # URL
-    qp = st.query_params
-    if "t" in qp:
-        del qp["t"]
-    st.query_params = qp
-    # 👇 NEW: clear LocalStorage
-    _localstorage_set(None)
+    """Clear any persisted authentication information."""
+    _clear_token()
 
 
 def get_auth_token() -> str | None:
-    # 1) memory
-    if TOKEN_KEY in st.session_state:
-        return st.session_state[TOKEN_KEY]
-    # 2) URL
-    t = st.query_params.get("t")
-    if t:
-        try:
-            tok = _decode(t)
-            st.session_state[TOKEN_KEY] = tok
-            # ensure mirror in LocalStorage
-            _localstorage_set(_encode(tok))
-            return tok
-        except Exception:
-            pass
-    # 3) 👇 NEW: LocalStorage
-    b64 = _localstorage_get()
-    if b64:
-        try:
-            tok = _decode(b64)
-            st.session_state[TOKEN_KEY] = tok
-            # ensure URL for subsequent refreshes
-            qp = st.query_params
-            if qp.get("t") != b64:
-                qp["t"] = b64
-                st.query_params = qp
-            return tok
-        except Exception:
-            pass
-    return None
+    """Return the current token, loading it from LocalStorage if needed."""
+    return _current_token()
 
 
 def is_authenticated() -> bool:
-    return get_auth_token() is not None
+    """Check whether a valid token + profile exist in the session."""
+    if not _ensure_authenticated():
+        return False
+    return _current_token() is not None
 
 
 def remember_current_page(page_name: str):
@@ -114,14 +52,20 @@ def clear_page_remember():
     st.query_params = qp
 
 
-# 👇 NEW: bootstrap helper
 def bootstrap_auth_once():
-    """
-    Attempts to restore the token from session_state, query params or LocalStorage.
-    Should be called at the start of Home.py once per render session.
-    """
     flag = "_auth_bootstrapped"
     if st.session_state.get(flag):
         return
-    _ = get_auth_token()
+    _ensure_authenticated()
     st.session_state[flag] = True
+
+
+__all__ = [
+    "set_auth_token",
+    "clear_auth_token",
+    "get_auth_token",
+    "is_authenticated",
+    "remember_current_page",
+    "clear_page_remember",
+    "bootstrap_auth_once",
+]

--- a/streamlit_app/utils/http_client.py
+++ b/streamlit_app/utils/http_client.py
@@ -3,7 +3,8 @@ import requests
 from typing import Any, Dict, Optional
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from .auth_session import get_auth_token
+
+from streamlit_app.auth_client import current_token
 
 BASE_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
@@ -49,7 +50,7 @@ DEFAULT_TIMEOUT = (3.05, 15)  # (connect, read)
 
 def _base_headers() -> Dict[str, str]:
     h: Dict[str, str] = {"Accept": "application/json"}
-    tok = get_auth_token()
+    tok = current_token()
     if tok:
         h["Authorization"] = f"Bearer {tok}"
     return h

--- a/streamlit_app/utils/logout_button.py
+++ b/streamlit_app/utils/logout_button.py
@@ -1,10 +1,13 @@
 import streamlit as st
-from .auth_session import clear_auth_token, clear_page_remember
+
+from streamlit_app.auth_client import clear_token
+from .auth_session import clear_page_remember
 from .nav import go
 
 
 def logout_button():
     if st.button("Cerrar sesión", type="secondary"):
-        clear_auth_token()
+        clear_token()
         clear_page_remember()
         go("Home.py")
+        st.rerun()


### PR DESCRIPTION
## Summary
- add an auth_client helper that syncs the JWT between Streamlit session_state and LocalStorage while validating it with `/me`
- rework the Home login flow to persist tokens, reload user info on refresh, and cleanly log out
- update all authenticated pages and utilities to rely on the new helpers and include the JWT header on backend calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d44276c8f88323ad1f26881a82bafd