### PR TITLE
Standardize plan quotas payload and usage tracking

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,7 @@ from backend.core.usage_helpers import (
     consume_lead_credits,
     day_key,
     inc_count,
+    month_key,
     register_ia_message,
 )
 from backend.core.usage_service import UsageService
@@ -2018,6 +2019,8 @@ def buscar_leads(payload: LeadsPayload, usuario=Depends(get_current_user), db: S
             saved = cap
             duplicates += max(excess, 0)
         consume_free_search(db, usuario.id, plan_name)
+        if saved:
+            inc_count(db, usuario.id, "leads", month_key(), saved)
         credits_remaining = None
     else:
         nuevos_unicos = max(payload.nuevos - payload.duplicados, 0)

--- a/backend/models.py
+++ b/backend/models.py
@@ -122,6 +122,7 @@ class UserUsageMonthly(Base):
     user_id = Column(Integer, index=True, nullable=False)
     period_yyyymm = Column(String, index=True, nullable=False)
     leads = Column(Integer, default=0)
+    searches = Column(Integer, default=0)
     ia_msgs = Column(Integer, default=0)
     tasks = Column(Integer, default=0)
     csv_exports = Column(Integer, default=0)

--- a/streamlit_app/pages/8_Mi_Cuenta.py
+++ b/streamlit_app/pages/8_Mi_Cuenta.py
@@ -1,6 +1,7 @@
 # 8_Mi_Cuenta.py – Página de cuenta de usuario
 
 import os
+
 import requests
 import streamlit as st
 from dotenv import load_dotenv
@@ -38,6 +39,9 @@ ALIASES_MAP = {
         "busquedas_mes",
         "leads_month",
         "free_searches",
+        "free_searches_per_month",
+        "searches_month",
+        "searches_monthly",
     ],
     "mensajes_ia": [
         "mensajes_ia",
@@ -46,6 +50,7 @@ ALIASES_MAP = {
         "ai_messages",
         "ai daily limit",
         "ai_daily_limit",
+        "ai_msgs",
     ],
     "leads_mes": [
         "leads_mes",
@@ -55,10 +60,11 @@ ALIASES_MAP = {
         "lead_credits_month",
         "lead_usage",
         "leads_used",
+        "leads_monthly",
     ],
 }
 
-PLAN_ENDPOINTS = ("/mi_plan", "/plan/quotas")
+PLAN_ENDPOINTS = ("/mi_plan", "/plan/quotas", "/plan/usage")
 
 
 def _fmt_limit(value) -> str:
@@ -341,6 +347,10 @@ if "auth_email" not in st.session_state and user:
 # Recuperar plan y límites/uso
 mi_plan = _fetch_plan_payload(token) or {}
 plan = str(mi_plan.get("plan", "free")).strip().lower()
+
+if is_debug_ui_enabled() and mi_plan:
+    with st.expander("Debug /mi_plan"):
+        st.json(mi_plan)
 
 with st.sidebar:
     logout_button()


### PR DESCRIPTION
## Summary
- standardize the plan quota payload to expose canonical limits, usage, remaining quotas, and current period metadata while keeping legacy keys for compatibility
- align usage tracking helpers and services with canonical metric names, add a persisted monthly searches column, and ensure free searches also record lead usage counts
- update the Mi Cuenta Streamlit page with broader endpoint fallbacks, additional alias coverage, and optional debugging output for the raw quota payload

## Testing
- pytest tests/test_schema_enforcement.py

------
https://chatgpt.com/codex/tasks/task_e_68d69349946c8323bbd45658bd2170ec