### PR TITLE
Fix daily AI message usage handling

### DIFF
--- a/backend/core/plan_config.py
+++ b/backend/core/plan_config.py
@@ -27,7 +27,7 @@ PLANES: Dict[str, PlanConfig] = {
         csv_exports_per_month=1,
         csv_rows_cap_free=10,
         tasks_active_max=3,
-        ai_daily_limit=5,
+        ai_daily_limit=10,
         queue_priority=0,
     ),
     "starter": PlanConfig(

--- a/backend/core/plan_service.py
+++ b/backend/core/plan_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from backend.core.plan_config import PLANES, get_limits as _get_plan_limits
 from backend.core.stripe_mapping import stripe_price_to_plan
-from backend.core.usage_service import UsageService, UsageDailyService
+from backend.core.usage_service import UsageService
 from backend.models import LeadTarea
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 
 def get_limits(plan_name: str):
     """Return the dataclass with plan limits for the given plan name."""
-    return _get_plan_limits(plan_name)
+    normalized = (plan_name or "free").strip().lower()
+    return _get_plan_limits(normalized)
 
 
 class PlanService:
@@ -64,45 +65,35 @@ class PlanService:
         plan_name, plan = self.get_effective_plan(user)
         usage_svc = UsageService(self.db)
         period = usage_svc.get_period_yyyymm()
-        counts = usage_svc.get_usage(user.id, period)
-        daily_usage_svc = UsageDailyService(self.db)
-        day_period = daily_usage_svc.get_period_yyyymmdd()
-        try:
-            daily_counts = daily_usage_svc.get_usage(user.id, day_period)
-        except Exception as exc:  # noqa: BLE001 - we want to swallow all runtime errors
-            logger.warning(
-                "daily usage lookup failed user_id=%s period=%s: %s",
-                getattr(user, "id", None),
-                day_period,
-                exc,
-                exc_info=exc,
-            )
+        counts = usage_svc.get_usage(user.id, period) or {}
+
+        from backend.core.usage_helpers import AI_ALIASES_READ, day_key, get_count
+
+        today = day_key()
+        ia_used_today = 0
+        for key in AI_ALIASES_READ:
             try:
-                self.db.rollback()
-            except Exception:
-                pass
-            daily_counts = {"ia_msgs": 0}
+                ia_used_today = max(
+                    ia_used_today, int(get_count(self.db, user.id, key, today))
+                )
+            except Exception as exc:  # noqa: BLE001 - legacy rows may not cast cleanly
+                logger.debug(
+                    "failed to read ai usage alias=%s user_id=%s: %s",
+                    key,
+                    getattr(user, "id", None),
+                    exc,
+                )
+                continue
 
-        if not isinstance(daily_counts, dict):
-            daily_counts = {"ia_msgs": 0}
+        ai_daily_limit = plan.ai_daily_limit
+        ai_remaining_today = (
+            None if ai_daily_limit is None else max(int(ai_daily_limit) - ia_used_today, 0)
+        )
+        day_period = today
 
-        mensajes_ia_today = 0
-        seen_ai_keys: set[str] = set()
-        for key in ("ia_msgs", "mensajes_ia", "ai_messages", "ia_mensajes"):
-            if key in daily_counts and key not in seen_ai_keys:
-                try:
-                    mensajes_ia_today += int(daily_counts.get(key) or 0)
-                except (TypeError, ValueError):
-                    continue
-                seen_ai_keys.add(key)
-
-        ia_msgs_current = mensajes_ia_today
-
-        ai_remaining_today: int | None
-        if plan.ai_daily_limit is None:
-            ai_remaining_today = None
-        else:
-            ai_remaining_today = max(plan.ai_daily_limit - ia_msgs_current, 0)
+        leads_used = int(counts.get("leads", 0) or 0)
+        tasks_used = int(counts.get("tasks", 0) or 0)
+        csv_exports_used = int(counts.get("csv_exports", 0) or 0)
 
         tasks_current = (
             self.db.query(LeadTarea)
@@ -120,34 +111,34 @@ class PlanService:
             "csv_rows_cap_free": plan.csv_rows_cap_free if plan.type == "free" else None,
             "lead_credits_month": plan.lead_credits_month if plan.type == "paid" else None,
             "tasks_active_max": plan.tasks_active_max,
-            "ai_daily_limit": plan.ai_daily_limit,
+            "ai_daily_limit": ai_daily_limit,
         }
 
         usage = {
             "leads": {
-                "used": counts["leads"],
-                "remaining": (plan.lead_credits_month - counts["leads"])
+                "used": leads_used,
+                "remaining": (plan.lead_credits_month - leads_used)
                 if plan.lead_credits_month is not None
                 else None,
                 "period": period,
             },
             "ia_msgs": {
-                "used": ia_msgs_current,
+                "used": ia_used_today,
                 "period": day_period,
-                "used_today": ia_msgs_current,
+                "used_today": ia_used_today,
                 "remaining_today": ai_remaining_today,
-                "limit": plan.ai_daily_limit,
+                "limit": ai_daily_limit,
             },
             "ai_messages": {
-                "used_today": ia_msgs_current,
+                "used_today": ia_used_today,
                 "remaining_today": ai_remaining_today,
-                "limit": plan.ai_daily_limit,
+                "limit": ai_daily_limit,
                 "period": day_period,
             },
-            "tasks": {"used": counts["tasks"], "period": period},
+            "tasks": {"used": tasks_used, "period": period},
             "csv_exports": {
-                "used": counts["csv_exports"],
-                "remaining": (plan.csv_exports_per_month - counts["csv_exports"])
+                "used": csv_exports_used,
+                "remaining": (plan.csv_exports_per_month - csv_exports_used)
                 if plan.csv_exports_per_month is not None
                 else None,
                 "period": period,
@@ -157,26 +148,26 @@ class PlanService:
 
         if plan.type == "free":
             usage["searches"] = {
-                "used": counts["leads"],
-                "remaining": (plan.searches_per_month - counts["leads"])
+                "used": leads_used,
+                "remaining": (plan.searches_per_month - leads_used)
                 if plan.searches_per_month is not None
                 else None,
                 "period": period,
             }
         else:
             usage["lead_credits"] = {
-                "used": counts["leads"],
-                "remaining": (plan.lead_credits_month - counts["leads"])
+                "used": leads_used,
+                "remaining": (plan.lead_credits_month - leads_used)
                 if plan.lead_credits_month is not None
                 else None,
                 "period": period,
             }
 
-        usage.setdefault("leads_mes", counts["leads"])
-        usage["mensajes_ia"] = ia_msgs_current
-        usage.setdefault("ia_msgs_total", ia_msgs_current)
-        usage.setdefault("ai_messages_total", ia_msgs_current)
-        usage.setdefault("searches_per_month", counts["leads"])
+        usage.setdefault("leads_mes", leads_used)
+        usage["mensajes_ia"] = ia_used_today
+        usage.setdefault("ia_msgs_total", ia_used_today)
+        usage.setdefault("ai_messages_total", ia_used_today)
+        usage.setdefault("searches_per_month", leads_used)
 
         remaining = {
             "leads": usage["leads"]["remaining"],
@@ -190,13 +181,13 @@ class PlanService:
 
         if plan.type == "free":
             remaining["searches"] = (
-                (plan.searches_per_month - counts["leads"])
+                (plan.searches_per_month - leads_used)
                 if plan.searches_per_month is not None
                 else None
             )
         else:
             remaining["lead_credits"] = (
-                (plan.lead_credits_month - counts["leads"])
+                (plan.lead_credits_month - leads_used)
                 if plan.lead_credits_month is not None
                 else None
             )

--- a/streamlit_app/pages/2_Asistente_Virtual.py
+++ b/streamlit_app/pages/2_Asistente_Virtual.py
@@ -213,22 +213,72 @@ def _auth_headers():
     return {"Authorization": f"Bearer {token}"} if token else {}
 
 
+def _ai_remaining_from_quotas() -> dict:
+    """Lee /plan/quotas y devuelve {'ok': bool, 'remaining': int|None}."""
+    try:
+        r = http_client.get("/plan/quotas", headers=_auth_headers())
+        if getattr(r, "status_code", None) != 200:
+            return {"ok": False, "remaining": None}
+        data = r.json() or {}
+        limits = data.get("limits") or data.get("limites") or {}
+        usage = data.get("usage") or data.get("uso") or {}
+
+        raw_limit = (
+            limits.get("ai_daily_limit")
+            or limits.get("ai daily limit")
+            or limits.get("mensajes_ia")
+        )
+        limit = None if raw_limit in (None, True, "∞", "unlimited", "ilimitado") else int(raw_limit)
+
+        used = (
+            usage.get("mensajes_ia")
+            or usage.get("ai_messages")
+            or usage.get("ia_mensajes")
+            or 0
+        )
+        used = int(used or 0)
+
+        if limit is None:
+            return {"ok": True, "remaining": None}
+
+        remaining = max(limit - used, 0)
+        return {"ok": remaining > 0, "remaining": remaining}
+    except Exception:
+        return {"ok": False, "remaining": None}
+
+
 def _consume_ai_message(prompt_text: str) -> dict:
-    """Reserva un mensaje de IA a través del backend antes de llamar a OpenAI."""
+    """
+    Reserva un mensaje de IA en backend. Si la respuesta de /ia no trae
+    remaining coherente, revalida con /plan/quotas y corrige.
+    Retorna: {'ok': bool, 'limit': bool, 'detail': any, 'remaining_today': int|None}
+    """
     try:
         r = http_client.post(
             "/ia",
             json={"prompt": (prompt_text or "").strip()},
             headers=_auth_headers(),
         )
-        if getattr(r, "status_code", None) == 200:
-            return r.json() if callable(getattr(r, "json", None)) else {"ok": True}
         if getattr(r, "status_code", None) == 403:
             try:
                 data = r.json()
             except Exception:
-                data = {"detail": r.text}
-            return {"ok": False, "limit": True, "detail": data}
+                data = {"detail": getattr(r, "text", "")}
+            return {"ok": False, "limit": True, "detail": data, "remaining_today": 0}
+
+        if getattr(r, "status_code", None) == 200:
+            data = r.json() if callable(getattr(r, "json", None)) else {"ok": True}
+            remaining = data.get("remaining_today", None)
+
+            chk = _ai_remaining_from_quotas()
+            if chk["remaining"] is not None:
+                if remaining is None or remaining > chk["remaining"]:
+                    remaining = chk["remaining"]
+                data["remaining_today"] = remaining
+                data["ok"] = bool(remaining > 0)
+
+            return data
+
         return {"ok": False, "detail": getattr(r, "text", "")}
     except Exception as e:
         return {"ok": False, "detail": str(e)}
@@ -1010,8 +1060,10 @@ if pregunta:
         st.markdown(pregunta)
 
     consume = _consume_ai_message(pregunta)
-    if not consume.get("ok"):
-        if consume.get("limit"):
+    remaining_today = consume.get("remaining_today") if isinstance(consume, dict) else None
+
+    if not consume.get("ok") or (remaining_today is not None and remaining_today <= 0):
+        if consume.get("limit") or (remaining_today is not None and remaining_today <= 0):
             with st.chat_message("assistant"):
                 st.warning("Has alcanzado el límite diario de *Mensajes IA* de tu plan.")
                 subscription_cta()
@@ -1021,11 +1073,10 @@ if pregunta:
                     "content": "Has alcanzado el límite diario de Mensajes IA. Para continuar, actualiza tu plan.",
                 }
             )
-            st.stop()
         else:
             with st.chat_message("assistant"):
                 st.warning("No he podido validar tu cuota de IA. Inténtalo de nuevo en unos segundos.")
-            st.stop()
+        st.stop()
 
     # Cualquier intento de extraer o exportar leads desde el asistente devuelve el mensaje oficial.
     if es_intencion_extraer_leads(pregunta):
@@ -1033,7 +1084,6 @@ if pregunta:
         st.session_state.chat.append({"role": "assistant", "content": content})
         with st.chat_message("assistant"):
             st.markdown(content)
-            remaining_today = consume.get("remaining_today") if isinstance(consume, dict) else None
             if remaining_today is not None:
                 st.caption(f"Mensajes IA restantes hoy: {remaining_today}")
         st.stop()
@@ -1083,7 +1133,6 @@ if pregunta:
         st.session_state.chat.append({"role": "assistant", "content": content})
         with st.chat_message("assistant"):
             st.markdown(content)
-            remaining_today = consume.get("remaining_today") if isinstance(consume, dict) else None
             if remaining_today is not None:
                 st.caption(f"Mensajes IA restantes hoy: {remaining_today}")
 


### PR DESCRIPTION
## Summary
- normalize AI usage tracking around the `mensajes_ia` metric with alias support and correct plan limits
- expose daily AI usage and limits through the plan service quotas payloads
- update the `/ia` endpoint to enforce daily caps, persist increments once, and report the remaining allowance

## Testing
- pytest tests/test_usage_daily_resilience.py

------
https://chatgpt.com/codex/tasks/task_e_68d80b83a25083238b7924873766960b