### PR TITLE
Fix AI assistant quota enforcement and sync usage counters

### DIFF
--- a/backend/core/plan_service.py
+++ b/backend/core/plan_service.py
@@ -113,6 +113,10 @@ class PlanService:
             "tasks_active_max": plan.tasks_active_max,
             "ai_daily_limit": ai_daily_limit,
         }
+        limits["mensajes_ia"] = ai_daily_limit
+        limits["ai_messages"] = ai_daily_limit
+        limits["ia_mensajes"] = ai_daily_limit
+        limits["ia_msgs"] = ai_daily_limit
 
         usage = {
             "leads": {
@@ -130,6 +134,7 @@ class PlanService:
                 "limit": ai_daily_limit,
             },
             "ai_messages": {
+                "used": ia_used_today,
                 "used_today": ia_used_today,
                 "remaining_today": ai_remaining_today,
                 "limit": ai_daily_limit,

--- a/tests/test_ai_quota_endpoint.py
+++ b/tests/test_ai_quota_endpoint.py
@@ -1,0 +1,66 @@
+import importlib
+
+from tests.helpers import auth, set_plan
+
+
+def _freeze_day(monkeypatch, value: str = "20240201"):
+    usage_helpers = importlib.import_module("backend.core.usage_helpers")
+    main_module = importlib.import_module("backend.main")
+    monkeypatch.setattr(usage_helpers, "day_key", lambda _dt=None: value)
+    monkeypatch.setattr(main_module, "day_key", lambda _dt=None: value)
+
+
+def test_ai_endpoint_returns_remaining_after_use(client, monkeypatch):
+    headers = auth(client, "ai-quota-basic@example.com")
+    _freeze_day(monkeypatch, "20240210")
+
+    resp = client.post("/ia", json={"prompt": "hola"}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("ok") is True
+    assert data.get("remaining_today") == 9
+
+
+def test_ai_endpoint_blocks_after_daily_limit(client, monkeypatch):
+    headers = auth(client, "ai-quota-limit@example.com")
+    _freeze_day(monkeypatch, "20240211")
+
+    for _ in range(9):
+        resp = client.post("/ia", json={"prompt": "hola"}, headers=headers)
+        assert resp.status_code == 200
+
+    resp = client.post("/ia", json={"prompt": "hola"}, headers=headers)
+    assert resp.status_code == 200
+    assert resp.json().get("remaining_today") == 0
+
+    resp = client.post("/ia", json={"prompt": "hola"}, headers=headers)
+    assert resp.status_code == 403
+    detail = resp.json().get("detail", {})
+    assert detail.get("resource") == "ai"
+    assert detail.get("remaining") == 0
+
+
+def test_ai_endpoint_allows_unlimited_plan(client, db_session, monkeypatch):
+    headers = auth(client, "ai-quota-unlimited@example.com")
+
+    plan_config = importlib.import_module("backend.core.plan_config")
+    monkeypatch.setitem(
+        plan_config.PLANES,
+        "infinite",
+        plan_config.PlanConfig(
+            type="paid",
+            lead_credits_month=100,
+            csv_unlimited=True,
+            tasks_active_max=50,
+            ai_daily_limit=None,
+        ),
+    )
+    set_plan(db_session, "ai-quota-unlimited@example.com", "infinite")
+
+    _freeze_day(monkeypatch, "20240212")
+
+    for _ in range(3):
+        resp = client.post("/ia", json={"prompt": "hola"}, headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data.get("remaining_today") is None


### PR DESCRIPTION
## Summary
- normalize AI quota limits and expose alias data so the backend consistently reports remaining usage
- update the /ia endpoint and Streamlit assistant to honor daily limits, display accurate remaining counts, and disable input once exhausted
- add tests covering remaining counters, limit enforcement, and unlimited plan behavior

## Testing
- pytest tests/test_ai_quota_endpoint.py tests/test_free_plan_limits.py

------
https://chatgpt.com/codex/tasks/task_e_68d81fe7f7b88323b66d4ceb98f60383